### PR TITLE
feat: add multi-cluster ClickHouse support

### DIFF
--- a/example.env
+++ b/example.env
@@ -1,6 +1,14 @@
+# Default ClickHouse cluster (for mainnet, sepolia, holesky, hoodi)
 XATU_CLICKHOUSE_USERNAME=
 XATU_CLICKHOUSE_PASSWORD=
 XATU_CLICKHOUSE_HOST=clickhouse.xatu.ethPandaOps.io
+
+# Experimental ClickHouse cluster (for all other networks)
+XATU_CLICKHOUSE_EXPERIMENTAL_USERNAME=
+XATU_CLICKHOUSE_EXPERIMENTAL_PASSWORD=
+XATU_CLICKHOUSE_EXPERIMENTAL_HOST=
+
+# API Keys
 BEACONCHAIN_BASE_URL=https://beaconcha.in
 BEACONCHAIN_API_KEY=
 RATED_API_KEY=

--- a/pages/analysis/attestation_cdf/polars_data_loaders.py
+++ b/pages/analysis/attestation_cdf/polars_data_loaders.py
@@ -26,7 +26,7 @@ def load_attestation_timing_data_polars(start_time, end_time, network="mainnet",
     logger.info(f"Loading attestation data for missed slots: network={network}, data_source={data_source}")
     logger.info(f"Time range: {start_time} to {end_time}")
     
-    conn = get_database_connection()
+    conn = get_database_connection(network)
     
     # Times are now passed in UTC from the dashboard
     from datetime import timezone
@@ -175,7 +175,7 @@ def load_raw_attestation_data_for_slow_analysis(start_time, end_time, network="m
     """Load raw attestation data with validator indices for slow period analysis."""
     logger.info(f"Loading raw attestation data for slow analysis: network={network}, data_source={data_source}, include_observer_nodes={include_observer_nodes}")
     
-    conn = get_database_connection()
+    conn = get_database_connection(network)
     
     # Get data source configuration
     source_config = get_data_source_options()[data_source]
@@ -412,7 +412,7 @@ def load_proposer_duties_for_missed_slots(missed_slots, network="mainnet"):
         logger.warning(f"Too many missed slots ({len(missed_slots)}), limiting to most recent 1000")
         missed_slots = sorted(missed_slots)[-1000:]
     
-    conn = get_database_connection()
+    conn = get_database_connection(network)
     
     try:
         # Convert slots to comma-separated string

--- a/pages/analysis/gas_usage_performance/data_loaders.py
+++ b/pages/analysis/gas_usage_performance/data_loaders.py
@@ -57,7 +57,7 @@ def load_block_gossip_data(
     Returns:
         DataFrame with block gossip timing data
     """
-    conn = get_database_connection()
+    conn = get_database_connection(network)
     config = get_analysis_config()
     
     query = """
@@ -114,7 +114,7 @@ def load_head_time_data(
     Returns:
         DataFrame with head timing data
     """
-    conn = get_database_connection()
+    conn = get_database_connection(network)
     config = get_analysis_config()
     
     query = """
@@ -221,7 +221,7 @@ def load_canonical_block_data(
     Returns:
         DataFrame with block and gas usage data
     """
-    conn = get_database_connection()
+    conn = get_database_connection(network)
     
     query = """
     SELECT
@@ -284,7 +284,7 @@ def load_blob_sidecar_counts(
     Returns:
         DataFrame with blob counts per slot
     """
-    conn = get_database_connection()
+    conn = get_database_connection(network)
     
     query = """
     SELECT

--- a/pages/analysis/gas_usage_performance/polars_data_loaders.py
+++ b/pages/analysis/gas_usage_performance/polars_data_loaders.py
@@ -102,7 +102,7 @@ def load_block_gossip_data_polars(
         # Normalize time range (no longer truncates)
         norm_start, norm_end, _ = normalize_time_range(start_date, end_date)
         
-        conn = get_database_connection()
+        conn = get_database_connection(network)
         config = get_analysis_config()
         
         # Query without LIMIT - get ALL data in time range
@@ -199,7 +199,7 @@ def load_head_time_data_polars(
         # Normalize time range
         norm_start, norm_end, _ = normalize_time_range(start_date, end_date)
         
-        conn = get_database_connection()
+        conn = get_database_connection(network)
         config = get_analysis_config()
         
         # Complete query getting ALL head time data without limits
@@ -334,7 +334,7 @@ def load_canonical_block_data_polars(
         # Normalize time range
         norm_start, norm_end, _ = normalize_time_range(start_date, end_date)
         
-        conn = get_database_connection()
+        conn = get_database_connection(network)
         
         query = """
         SELECT
@@ -423,7 +423,7 @@ def load_blob_sidecar_counts_polars(
         # Normalize time range
         norm_start, norm_end, _ = normalize_time_range(start_date, end_date)
         
-        conn = get_database_connection()
+        conn = get_database_connection(network)
         
         query = """
         SELECT
@@ -479,7 +479,7 @@ def load_raw_data_as_polars(
     Returns:
         Tuple of (gossip_pl, head_pl, block_pl, blob_pl)
     """
-    conn = get_database_connection()
+    conn = get_database_connection(network)
     config = get_analysis_config()
     
     # Load gossip data

--- a/pages/analysis/validator_performance/data_loaders.py
+++ b/pages/analysis/validator_performance/data_loaders.py
@@ -24,7 +24,7 @@ def load_validator_indices(pubkeys: List[str], network: str) -> Tuple[Dict[str, 
     
     conn = None
     try:
-        conn = get_database_connection()
+        conn = get_database_connection(network)
         
         # Build the query with proper formatting for ClickHouse IN clause
         # Convert pubkeys list to a comma-separated string of quoted values

--- a/shared/clickhouse_manager.py
+++ b/shared/clickhouse_manager.py
@@ -1,0 +1,138 @@
+"""
+ClickHouse connection manager for multi-cluster support
+"""
+import os
+from typing import Dict, Optional, Any
+from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine, Connection
+import streamlit as st
+import dotenv
+
+# Load environment variables
+dotenv.load_dotenv()
+
+
+class ClickHouseClusterConfig:
+    """Configuration for a ClickHouse cluster"""
+    def __init__(self, name: str, username_env: str, password_env: str, host_env: str):
+        self.name = name
+        self.username_env = username_env
+        self.password_env = password_env
+        self.host_env = host_env
+    
+    def get_connection_url(self) -> Optional[str]:
+        """Get connection URL for this cluster"""
+        username = os.getenv(self.username_env)
+        password = os.getenv(self.password_env)
+        host = os.getenv(self.host_env)
+        
+        if not all([username, password, host]):
+            return None
+            
+        return f"clickhouse+http://{username}:{password}@{host}:443/default?protocol=https"
+
+
+class ClickHouseConnectionManager:
+    """Manages connections to multiple ClickHouse clusters"""
+    
+    def __init__(self):
+        # Define cluster configurations
+        self.clusters: Dict[str, ClickHouseClusterConfig] = {
+            'default': ClickHouseClusterConfig(
+                name='default',
+                username_env='XATU_CLICKHOUSE_USERNAME',
+                password_env='XATU_CLICKHOUSE_PASSWORD',
+                host_env='XATU_CLICKHOUSE_HOST'
+            ),
+            'experimental': ClickHouseClusterConfig(
+                name='experimental',
+                username_env='XATU_CLICKHOUSE_EXPERIMENTAL_USERNAME',
+                password_env='XATU_CLICKHOUSE_EXPERIMENTAL_PASSWORD',
+                host_env='XATU_CLICKHOUSE_EXPERIMENTAL_HOST'
+            )
+        }
+        
+        # Define network to cluster routing
+        self.network_routing: Dict[str, str] = {
+            'mainnet': 'default',
+            'sepolia': 'default',
+            'holesky': 'default',
+            'hoodi': 'default',
+            # All other networks will route to 'experimental'
+        }
+        
+        # Cache for database engines
+        self._engines: Dict[str, Engine] = {}
+    
+    def get_cluster_for_network(self, network: str) -> str:
+        """Get the cluster name for a given network"""
+        return self.network_routing.get(network, 'experimental')
+    
+    def get_engine_for_cluster(self, cluster_name: str) -> Optional[Engine]:
+        """Get or create SQLAlchemy engine for a cluster"""
+        if cluster_name in self._engines:
+            return self._engines[cluster_name]
+        
+        if cluster_name not in self.clusters:
+            st.error(f"Unknown cluster: {cluster_name}")
+            return None
+        
+        cluster_config = self.clusters[cluster_name]
+        connection_url = cluster_config.get_connection_url()
+        
+        if not connection_url:
+            st.error(f"Missing credentials for {cluster_name} cluster. Please check your .env file.")
+            return None
+        
+        try:
+            engine = create_engine(connection_url)
+            self._engines[cluster_name] = engine
+            return engine
+        except Exception as e:
+            st.error(f"Failed to create engine for {cluster_name} cluster: {e}")
+            return None
+    
+    def get_connection_for_network(self, network: str) -> Optional[Connection]:
+        """Get database connection for a specific network"""
+        cluster_name = self.get_cluster_for_network(network)
+        engine = self.get_engine_for_cluster(cluster_name)
+        
+        if not engine:
+            return None
+        
+        try:
+            return engine.connect()
+        except Exception as e:
+            st.error(f"Failed to connect to {cluster_name} cluster for network {network}: {e}")
+            return None
+    
+    def add_cluster(self, name: str, config: ClickHouseClusterConfig):
+        """Add a new cluster configuration"""
+        self.clusters[name] = config
+    
+    def update_network_routing(self, network_routing: Dict[str, str]):
+        """Update network routing configuration"""
+        self.network_routing.update(network_routing)
+
+
+# Singleton instance
+@st.cache_resource
+def get_clickhouse_manager() -> ClickHouseConnectionManager:
+    """Get singleton ClickHouseConnectionManager instance"""
+    return ClickHouseConnectionManager()
+
+
+def get_clickhouse_client_for_network(network: str) -> Optional[Connection]:
+    """
+    Get ClickHouse connection for a specific network.
+    
+    This is the main entry point for getting network-specific database connections.
+    
+    Args:
+        network: The network name (e.g., 'mainnet', 'sepolia', 'experimental_network')
+    
+    Returns:
+        SQLAlchemy Connection object or None if connection fails
+    """
+    manager = get_clickhouse_manager()
+    return manager.get_connection_for_network(network)

--- a/shared/database.py
+++ b/shared/database.py
@@ -4,14 +4,30 @@ Database connection utilities for ethPandaOps Analysis Dashboard
 import os
 import streamlit as st
 from sqlalchemy import create_engine
+from typing import Optional
 import dotenv
+from .clickhouse_manager import get_clickhouse_client_for_network
 
 # Load environment variables
 dotenv.load_dotenv()
 
 
-def get_database_connection():
-    """Create database connection."""
+def get_database_connection(network: Optional[str] = None):
+    """
+    Create database connection.
+    
+    Args:
+        network: Optional network name. If provided, will use the appropriate cluster for that network.
+                If not provided, uses the default cluster (backward compatibility).
+    
+    Returns:
+        SQLAlchemy connection object or None if connection fails
+    """
+    # If network is specified, use the new multi-cluster manager
+    if network:
+        return get_clickhouse_client_for_network(network)
+    
+    # Otherwise, fall back to default behavior for backward compatibility
     try:
         username = os.getenv('XATU_CLICKHOUSE_USERNAME')
         password = os.getenv('XATU_CLICKHOUSE_PASSWORD')

--- a/shared/ethereum/attestations.py
+++ b/shared/ethereum/attestations.py
@@ -23,7 +23,7 @@ def load_attestation_data(time_ranges_str, network):
     """
     time_ranges = ast.literal_eval(time_ranges_str)
     
-    connection = get_database_connection()
+    connection = get_database_connection(network)
     if connection is None:
         return pd.DataFrame()
     

--- a/shared/ethereum/blocks.py
+++ b/shared/ethereum/blocks.py
@@ -23,7 +23,7 @@ def fetch_proposer_indices(time_ranges_str, network):
     """
     time_ranges = ast.literal_eval(time_ranges_str)
     
-    connection = get_database_connection()
+    connection = get_database_connection(network)
     if connection is None:
         return pd.DataFrame()
     

--- a/shared/ethereum/validators.py
+++ b/shared/ethereum/validators.py
@@ -19,7 +19,7 @@ def load_blockprint_clients(network):
     Returns:
         dict: Mapping of proposer_index -> blockprint_client
     """
-    connection = get_database_connection()
+    connection = get_database_connection(network)
     if connection is None:
         return {}
         
@@ -90,7 +90,7 @@ def load_validators_from_ethseer(network):
     Returns:
         dict: Mapping of proposer_index -> entity
     """
-    connection = get_database_connection()
+    connection = get_database_connection(network)
     if connection is None:
         return {}
         


### PR DESCRIPTION
## Summary
- Added support for connecting to multiple ClickHouse clusters based on network name
- Implemented network-based routing configuration for flexible cluster management

## Test plan
- [x] Test network routing logic (mainnet/sepolia/holesky/hoodi → default cluster)
- [x] Test experimental network routing (other networks → experimental cluster)
- [x] Verify backward compatibility (calls without network parameter still work)
- [ ] Test with actual experimental cluster credentials

🤖 Generated with [Claude Code](https://claude.ai/code)