### PR TITLE
bugfix: Use absolute import in pages

### DIFF
--- a/pages/CURSOR.mdc
+++ b/pages/CURSOR.mdc
@@ -23,5 +23,5 @@ Each analysis component follows consistent modular architecture:
 
 ## Key Constraints
 - Pages must be self-contained but leverage shared utilities for consistency
-- Use relative imports with proper path management for analysis subdirectories
+- Use absolute imports with proper path management for analysis subdirectories
 - Follow Streamlit session state management with prefixed keys for conflict prevention

--- a/pages/analysis/attestation_cdf/__init__.py
+++ b/pages/analysis/attestation_cdf/__init__.py
@@ -1,0 +1,1 @@
+# Attestation CDF Analysis package

--- a/pages/analysis/attestation_cdf/data_loaders.py
+++ b/pages/analysis/attestation_cdf/data_loaders.py
@@ -8,11 +8,11 @@ from shared.database import get_database_connection
 from shared.parquet_utils import calculate_parquet_urls, download_and_cache_parquet  
 from shared.ethereum.validators import load_validators_from_ethseer
 from shared.ethereum.blocks import fetch_proposer_indices
-from config_utils import get_supported_networks, get_data_source_options
-from _table_verification import verify_table_structures, get_verified_query_templates
+from pages.analysis.attestation_cdf.config_utils import get_supported_networks, get_data_source_options
+from pages.analysis.attestation_cdf._table_verification import verify_table_structures, get_verified_query_templates
 
 # Import polars functions - REQUIRED
-from polars_data_loaders import (
+from pages.analysis.attestation_cdf.polars_data_loaders import (
     load_attestation_timing_data_polars,
     load_combined_analysis_data_polars,
     load_raw_attestation_data_for_slow_analysis

--- a/pages/analysis/attestation_cdf/interactive_dashboard.py
+++ b/pages/analysis/attestation_cdf/interactive_dashboard.py
@@ -7,15 +7,15 @@ import plotly.graph_objects as go
 import plotly.express as px
 
 # Import components
-from config_utils import (
+from pages.analysis.attestation_cdf.config_utils import (
     get_metric_info, get_default_time_ranges, 
     get_supported_networks, get_grouping_options,
     get_data_source_options
 )
-from data_loaders import load_combined_analysis_data
-from polars_data_loaders import load_raw_attestation_data_for_slow_analysis, load_proposer_duties_for_missed_slots
-from metrics_calculators import calculate_node_cdf_metrics
-from plot_generators import create_cdf_comparison_plot, create_missed_slots_by_proposer_entity_chart
+from pages.analysis.attestation_cdf.data_loaders import load_combined_analysis_data
+from pages.analysis.attestation_cdf.polars_data_loaders import load_raw_attestation_data_for_slow_analysis, load_proposer_duties_for_missed_slots
+from pages.analysis.attestation_cdf.metrics_calculators import calculate_node_cdf_metrics
+from pages.analysis.attestation_cdf.plot_generators import create_cdf_comparison_plot, create_missed_slots_by_proposer_entity_chart
 from shared.ui_components import add_ethPandaOps_logo
 
 # Import shared components  

--- a/pages/analysis/attestation_cdf/page.py
+++ b/pages/analysis/attestation_cdf/page.py
@@ -1,25 +1,8 @@
 # pages/analysis/attestation_cdf/page.py
-import streamlit as st
-import sys
-import os
+"""Attestation CDF Analysis Dashboard"""
 
-# Get current directory and add it to sys.path so imports work
-current_dir = os.path.dirname(os.path.abspath(__file__))
-if current_dir not in sys.path:
-    sys.path.insert(0, current_dir)
+# Use proper absolute imports from project root
+from pages.analysis.attestation_cdf.interactive_dashboard import main
 
-# Import the dashboard module
-try:
-    # Import with the directory in path
-    from interactive_dashboard import main
-
-    # Run the dashboard
-    main()
-
-except ImportError as e:
-    import traceback
-    st.code(traceback.format_exc())
-except Exception as e:
-    st.error(f"Error running Attestation CDF Analysis dashboard: {e}")
-    import traceback
-    st.code(traceback.format_exc())
+# Run the dashboard
+main()

--- a/pages/analysis/attestation_cdf/plot_generators.py
+++ b/pages/analysis/attestation_cdf/plot_generators.py
@@ -5,7 +5,7 @@ import plotly.express as px
 import plotly.graph_objects as go
 from plotly.subplots import make_subplots
 from shared.ui_components import add_ethPandaOps_logo
-from config_utils import get_metric_info
+from pages.analysis.attestation_cdf.config_utils import get_metric_info
 
 
 def create_cdf_comparison_plot(aggregated_data, comparison_dimension=None, client_data=None, title=None, **kwargs):

--- a/pages/analysis/attestation_cdf/polars_data_loaders.py
+++ b/pages/analysis/attestation_cdf/polars_data_loaders.py
@@ -14,7 +14,7 @@ import logging
 
 from shared.database import get_database_connection
 from shared.config import get_network_genesis_timestamp
-from config_utils import get_data_source_options
+from pages.analysis.attestation_cdf.config_utils import get_data_source_options
 
 # Set up logging
 logger = logging.getLogger(__name__)

--- a/pages/analysis/block_producer_performance/interactive_dashboard.py
+++ b/pages/analysis/block_producer_performance/interactive_dashboard.py
@@ -10,18 +10,18 @@ Run with: streamlit run interactive_dashboard.py
 """
 
 # Import all the split components
-from config_utils import *
-from data_loaders import (
+from pages.analysis.block_producer_performance.config_utils import *
+from pages.analysis.block_producer_performance.data_loaders import (
     load_blockprint_clients,
     load_validators_from_ethseer,
     load_attestation_data_parquet, 
     fetch_proposer_indices_parquet
 )
-from metrics_calculators import (
+from pages.analysis.block_producer_performance.metrics_calculators import (
     calculate_first_seen_attestations,
     calculate_slot_metrics
 )
-from plot_generators import (
+from pages.analysis.block_producer_performance.plot_generators import (
     create_before_after_comparison,
     create_distribution_plot,
     create_time_series_plot,

--- a/pages/analysis/block_producer_performance/page.py
+++ b/pages/analysis/block_producer_performance/page.py
@@ -1,25 +1,6 @@
-# pages/analysis/block_producer_performance/page.py
-import streamlit as st
-import sys
-import os
+"""Block Producer Performance Analysis Dashboard"""
 
-# Get current directory and add it to sys.path so imports work
-current_dir = os.path.dirname(os.path.abspath(__file__))
-if current_dir not in sys.path:
-    sys.path.insert(0, current_dir)
+from pages.analysis.block_producer_performance.interactive_dashboard import main as run_dashboard
 
-# Import the dashboard module
-try:
-    # Import with the directory in path
-    from interactive_dashboard import main
-
-    # Run the dashboard
-    main()
-
-except ImportError as e:
-    import traceback
-    st.code(traceback.format_exc())
-except Exception as e:
-    st.error(f"Error running Block Producer Performance dashboard: {e}")
-    import traceback
-    st.code(traceback.format_exc())
+# Run the dashboard
+run_dashboard()

--- a/pages/analysis/gossipsub_monitoring/data_loaders.py
+++ b/pages/analysis/gossipsub_monitoring/data_loaders.py
@@ -12,8 +12,8 @@ import streamlit as st
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from shared.database import get_database_connection
-from queries import get_single_slot_complete_query
-from config_utils import get_continent_from_code
+from pages.analysis.gossipsub_monitoring.queries import get_single_slot_complete_query
+from pages.analysis.gossipsub_monitoring.config_utils import get_continent_from_code
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)

--- a/pages/analysis/gossipsub_monitoring/data_loaders_fixed.py
+++ b/pages/analysis/gossipsub_monitoring/data_loaders_fixed.py
@@ -13,8 +13,8 @@ import streamlit as st
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from shared.database import get_database_connection
-from queries_fixed import get_time_based_gossipsub_query, get_slots_in_range_simple, get_latest_slot_simple
-from config_utils import get_continent_from_code
+from pages.analysis.gossipsub_monitoring.queries_fixed import get_time_based_gossipsub_query, get_slots_in_range_simple, get_latest_slot_simple
+from pages.analysis.gossipsub_monitoring.config_utils import get_continent_from_code
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)

--- a/pages/analysis/gossipsub_monitoring/data_loaders_reverse.py
+++ b/pages/analysis/gossipsub_monitoring/data_loaders_reverse.py
@@ -11,7 +11,7 @@ import logging
 import streamlit as st
 
 from shared.database import get_database_connection
-from queries_reverse import (
+from pages.analysis.gossipsub_monitoring.queries_reverse import (
     get_ihave_based_slots_query, 
     get_ihave_data_for_slot_time,
     get_idontwant_data_for_slot_time,

--- a/pages/analysis/gossipsub_monitoring/interactive_dashboard.py
+++ b/pages/analysis/gossipsub_monitoring/interactive_dashboard.py
@@ -18,13 +18,13 @@ from shared.ui_components import apply_ethPandaOps_styling
 from shared.header import render_global_header, get_global_cluster, get_global_network
 
 # Import local modules
-from config_utils import (
+from pages.analysis.gossipsub_monitoring.config_utils import (
     get_default_time_ranges,
     get_supported_networks,
     get_data_source_options,
     get_analysis_config
 )
-from data_loaders_reverse import (
+from pages.analysis.gossipsub_monitoring.data_loaders_reverse import (
     load_gossipsub_data_reverse as load_gossipsub_data,
     get_latest_slot_with_ihave as get_latest_slot,
     get_available_slots_with_ihave as get_available_slots,
@@ -34,7 +34,7 @@ from data_loaders_reverse import (
     calculate_percentiles_by_slot,
     load_comparison_data
 )
-from plot_generators import (
+from pages.analysis.gossipsub_monitoring.plot_generators import (
     create_continent_cdf_plot,
     create_slot_cdf_plot,
     create_percentile_comparison_chart,

--- a/pages/analysis/gossipsub_monitoring/page.py
+++ b/pages/analysis/gossipsub_monitoring/page.py
@@ -1,25 +1,6 @@
-# pages/analysis/gossipsub_monitoring/page.py
-import streamlit as st
-import sys
-import os
+"""Gossipsub Monitoring Analysis Dashboard"""
 
-# Get current directory and add it to sys.path so imports work
-current_dir = os.path.dirname(os.path.abspath(__file__))
-if current_dir not in sys.path:
-    sys.path.insert(0, current_dir)
+from pages.analysis.gossipsub_monitoring.interactive_dashboard import main as run_dashboard
 
-# Import the dashboard module
-try:
-    # Import with the directory in path
-    from interactive_dashboard import main
-
-    # Run the dashboard
-    main()
-
-except ImportError as e:
-    import traceback
-    st.code(traceback.format_exc())
-except Exception as e:
-    st.error(f"Error running Gossipsub Monitoring dashboard: {e}")
-    import traceback
-    st.code(traceback.format_exc())
+# Run the dashboard
+run_dashboard()

--- a/pages/analysis/multi_metric_analysis/__init__.py
+++ b/pages/analysis/multi_metric_analysis/__init__.py
@@ -1,0 +1,1 @@
+# Multi-Metric Analysis package

--- a/pages/analysis/multi_metric_analysis/data_loaders.py
+++ b/pages/analysis/multi_metric_analysis/data_loaders.py
@@ -15,7 +15,7 @@ import warnings
 
 from shared.database import get_database_connection
 from shared.data_utils import memory_efficient_context, normalize_time_range, chunk_time_range
-from config_utils import get_analysis_config
+from pages.analysis.multi_metric_analysis.config_utils import get_analysis_config
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)

--- a/pages/analysis/multi_metric_analysis/interactive_dashboard.py
+++ b/pages/analysis/multi_metric_analysis/interactive_dashboard.py
@@ -20,12 +20,12 @@ logger = logging.getLogger(__name__)
 from shared.ui_components import apply_ethPandaOps_styling
 from shared.header import render_global_header, get_global_cluster, get_global_network
 from shared.metric_utils import get_metric_info
-from config_utils import (
+from pages.analysis.multi_metric_analysis.config_utils import (
     get_analysis_config, get_default_periods,
     validate_analysis_config
 )
-from data_loaders import load_complete_analysis_data
-from metrics_calculators import (
+from pages.analysis.multi_metric_analysis.data_loaders import load_complete_analysis_data
+from pages.analysis.multi_metric_analysis.metrics_calculators import (
     create_time_buckets,
     create_gas_buckets, 
     calculate_bucket_metrics,
@@ -38,14 +38,14 @@ from metrics_calculators import (
     calculate_gas_binned_analysis,
     calculate_comparative_analysis
 )
-from plot_generators import (
+from pages.analysis.multi_metric_analysis.plot_generators import (
     create_gas_vs_arrival_scatter, create_time_series_comparison, create_consensus_performance_heatmap,
     create_box_plot_comparison, create_correlation_matrix, create_geographic_performance_plot,
     create_gas_binned_performance_plot, create_multi_y_correlation_plot
 )
-from metric_discovery import discover_metrics, DataLineageTracker, format_bucket_size
-from dynamic_bucketing import create_dynamic_buckets
-from analysis_templates import get_template, get_template_names, get_default_template, save_template
+from pages.analysis.multi_metric_analysis.metric_discovery import discover_metrics, DataLineageTracker, format_bucket_size
+from pages.analysis.multi_metric_analysis.dynamic_bucketing import create_dynamic_buckets
+from pages.analysis.multi_metric_analysis.analysis_templates import get_template, get_template_names, get_default_template, save_template
 
 
 # Configure logging

--- a/pages/analysis/multi_metric_analysis/metrics_calculators.py
+++ b/pages/analysis/multi_metric_analysis/metrics_calculators.py
@@ -19,7 +19,7 @@ from shared.metric_utils import (
     calculate_temporal_trends as shared_calculate_temporal_trends,
     calculate_percentile_analysis as shared_calculate_percentile_analysis
 )
-from config_utils import get_analysis_config
+from pages.analysis.multi_metric_analysis.config_utils import get_analysis_config
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)

--- a/pages/analysis/multi_metric_analysis/page.py
+++ b/pages/analysis/multi_metric_analysis/page.py
@@ -1,25 +1,6 @@
-# pages/analysis/multi_metric_analysis/page.py
-import streamlit as st
-import sys
-import os
+"""Multi-Metric Performance Analysis Dashboard"""
 
-# Get current directory and add it to sys.path so imports work
-current_dir = os.path.dirname(os.path.abspath(__file__))
-if current_dir not in sys.path:
-    sys.path.insert(0, current_dir)
+from pages.analysis.multi_metric_analysis.interactive_dashboard import main as run_dashboard
 
-# Import the dashboard module
-try:
-    # Import with the directory in path
-    from interactive_dashboard import main
-
-    # Run the dashboard
-    main()
-
-except ImportError as e:
-    import traceback
-    st.code(traceback.format_exc())
-except Exception as e:
-    st.error(f"Error running Multi-Metric Performance Analysis dashboard: {e}")
-    import traceback
-    st.code(traceback.format_exc())
+# Run the dashboard
+run_dashboard()

--- a/pages/analysis/multi_metric_analysis/plot_generators.py
+++ b/pages/analysis/multi_metric_analysis/plot_generators.py
@@ -15,8 +15,8 @@ import logging
 
 from shared.ui_components import add_ethPandaOps_logo
 from shared.metric_utils import get_metric_info
-from config_utils import get_analysis_config, get_continents
-from metrics_calculators import calculate_correlation_analysis
+from pages.analysis.multi_metric_analysis.config_utils import get_analysis_config, get_continents
+from pages.analysis.multi_metric_analysis.metrics_calculators import calculate_correlation_analysis
 
 
 # Configure logging

--- a/pages/analysis/peerdas_analysis/__init__.py
+++ b/pages/analysis/peerdas_analysis/__init__.py
@@ -1,0 +1,1 @@
+# PeerDAS Analysis package

--- a/pages/analysis/peerdas_analysis/interactive_dashboard.py
+++ b/pages/analysis/peerdas_analysis/interactive_dashboard.py
@@ -18,22 +18,22 @@ logger = logging.getLogger(__name__)
 from shared.header import render_global_header, get_global_cluster, get_global_network
 
 # Import local modules
-from config_utils import (
+from pages.analysis.peerdas_analysis.config_utils import (
     get_analysis_config,
     get_data_source_options
 )
-from loader import (
+from pages.analysis.peerdas_analysis.loader import (
     load_peerdas_aggregated_data,
     load_node_classification_raw_data,
     validate_data_availability,
     get_max_blob_count,
     get_unique_clients
 )
-from plot_generators import (
+from pages.analysis.peerdas_analysis.plot_generators import (
     create_peerdas_performance_chart,
     create_node_classification_boxplot
 )
-from gap_analysis import create_node_performance_gap_analysis
+from pages.analysis.peerdas_analysis.gap_analysis import create_node_performance_gap_analysis
 
 
 def initialize_session_state():

--- a/pages/analysis/peerdas_analysis/loader.py
+++ b/pages/analysis/peerdas_analysis/loader.py
@@ -12,7 +12,7 @@ from typing import Optional, Dict, Any
 import logging
 
 from shared.database import get_database_connection
-from queries import (
+from pages.analysis.peerdas_analysis.queries import (
     get_peerdas_query, 
     get_node_classification_raw_query, 
     get_max_blob_count_query,

--- a/pages/analysis/peerdas_analysis/page.py
+++ b/pages/analysis/peerdas_analysis/page.py
@@ -1,25 +1,6 @@
-# pages/analysis/peerdas_analysis/page.py
-import streamlit as st
-import sys
-import os
+"""PeerDAS Analysis Dashboard"""
 
-# Get current directory and add it to sys.path so imports work
-current_dir = os.path.dirname(os.path.abspath(__file__))
-if current_dir not in sys.path:
-    sys.path.insert(0, current_dir)
+from pages.analysis.peerdas_analysis.interactive_dashboard import main as run_dashboard
 
-# Import the dashboard module
-try:
-    # Import with the directory in path
-    from interactive_dashboard import main
-
-    # Run the dashboard
-    main()
-
-except ImportError as e:
-    import traceback
-    st.code(traceback.format_exc())
-except Exception as e:
-    st.error(f"Error running PeerDAS Analysis dashboard: {e}")
-    import traceback
-    st.code(traceback.format_exc())
+# Run the dashboard
+run_dashboard()

--- a/pages/analysis/peerdas_analysis_v2/__init__.py
+++ b/pages/analysis/peerdas_analysis_v2/__init__.py
@@ -1,0 +1,1 @@
+# PeerDAS Analysis V2 package

--- a/pages/analysis/peerdas_analysis_v2/interactive_dashboard.py
+++ b/pages/analysis/peerdas_analysis_v2/interactive_dashboard.py
@@ -28,14 +28,14 @@ from shared.ethereum.validator_filters import (
 )
 
 # Import local modules
-from loader import (
+from pages.analysis.peerdas_analysis_v2.loader import (
     load_eligible_slots,
     load_head_correctness_data,
     validate_data_availability,
     get_unique_clients,
     load_network_mapping
 )
-from plot_generators import (
+from pages.analysis.peerdas_analysis_v2.plot_generators import (
     create_head_correctness_boxplot,
     create_head_correctness_chart,
     create_head_correctness_violin,

--- a/pages/analysis/peerdas_analysis_v2/page.py
+++ b/pages/analysis/peerdas_analysis_v2/page.py
@@ -1,25 +1,5 @@
-# pages/analysis/peerdas_analysis_v2/page.py
-import streamlit as st
-import sys
-import os
+"""Head Correctness Analysis Dashboard"""
 
-# Get current directory and add it to sys.path so imports work
-current_dir = os.path.dirname(os.path.abspath(__file__))
-if current_dir not in sys.path:
-    sys.path.insert(0, current_dir)
+from pages.analysis.peerdas_analysis_v2.interactive_dashboard import main as run_dashboard
 
-# Import the dashboard module
-try:
-    # Import with the directory in path
-    from interactive_dashboard import main
-    
-    # Run the dashboard
-    main()
-    
-except ImportError as e:
-    import traceback
-    st.code(traceback.format_exc())
-except Exception as e:
-    st.error(f"Error running Head Correctness dashboard: {e}")
-    import traceback
-    st.code(traceback.format_exc())
+run_dashboard()

--- a/pages/analysis/reorg_rates/__init__.py
+++ b/pages/analysis/reorg_rates/__init__.py
@@ -1,0 +1,1 @@
+# Reorg Rates Analysis package

--- a/pages/analysis/reorg_rates/interactive_dashboard.py
+++ b/pages/analysis/reorg_rates/interactive_dashboard.py
@@ -21,13 +21,13 @@ from shared.database import get_database_connection
 from shared.ethereum.validator_filters import create_proposer_filters_ui
 
 # Import local modules
-from loader import (
+from pages.analysis.reorg_rates.loader import (
     get_canonical_max_slot,
     load_eligible_slots,
     load_reorg_data,
     validate_canonical_data_availability
 )
-from plot_generators import (
+from pages.analysis.reorg_rates.plot_generators import (
     create_reorg_count_bar_chart,
     create_reorg_rate_chart,
     create_reorg_rate_boxplot,

--- a/pages/analysis/reorg_rates/page.py
+++ b/pages/analysis/reorg_rates/page.py
@@ -1,25 +1,5 @@
-# pages/analysis/reorg_rates/page.py
-import streamlit as st
-import sys
-import os
+"""Reorg Rates Analysis Dashboard"""
 
-# Get current directory and add it to sys.path so imports work
-current_dir = os.path.dirname(os.path.abspath(__file__))
-if current_dir not in sys.path:
-    sys.path.insert(0, current_dir)
+from pages.analysis.reorg_rates.interactive_dashboard import main as run_dashboard
 
-# Import the dashboard module
-try:
-    # Import with the directory in path
-    from interactive_dashboard import main
-
-    # Run the dashboard
-    main()
-
-except ImportError as e:
-    import traceback
-    st.code(traceback.format_exc())
-except Exception as e:
-    st.error(f"Error running Reorg Rates dashboard: {e}")
-    import traceback
-    st.code(traceback.format_exc())
+run_dashboard()

--- a/pages/analysis/reorgs/__init__.py
+++ b/pages/analysis/reorgs/__init__.py
@@ -1,0 +1,1 @@
+# Reorgs Analysis package

--- a/pages/analysis/reorgs/data_loaders.py
+++ b/pages/analysis/reorgs/data_loaders.py
@@ -6,7 +6,7 @@ import polars as pl
 import pandas as pd
 from datetime import datetime, timedelta
 from typing import Optional, Dict, List, Tuple
-from config_utils import get_depth_filter_config, get_client_normalization_rules
+from pages.analysis.reorgs.config_utils import get_depth_filter_config, get_client_normalization_rules
 
 # Import existing shared data loading functionality
 from shared.database import get_database_connection

--- a/pages/analysis/reorgs/interactive_dashboard.py
+++ b/pages/analysis/reorgs/interactive_dashboard.py
@@ -10,28 +10,28 @@ import pandas as pd
 import numpy as np
 
 # Import components
-from config_utils import (
+from pages.analysis.reorgs.config_utils import (
     get_metric_info, get_default_time_ranges, 
     get_depth_filter_config, get_aggregation_options
 )
-from data_loaders import (
+from pages.analysis.reorgs.data_loaders import (
     load_reorg_data, load_missed_slots_data, 
     load_reorg_episodes, load_client_metadata,
     deduplicate_reorg_events
 )
-from metrics_calculators import (
+from pages.analysis.reorgs.metrics_calculators import (
     calculate_basic_metrics, calculate_client_metrics,
     calculate_implementation_metrics, calculate_episode_metrics, 
     calculate_epoch_boundary_effects, correlate_with_missed_slots, 
     calculate_geographic_distribution
 )
-from plot_generators import (
+from pages.analysis.reorgs.plot_generators import (
     create_reorg_timeline, create_depth_distribution,
     create_client_comparison, create_epoch_boundary_heatmap,
     create_scatter_matrix, create_geographic_distribution
 )
 from shared.ui_components import add_ethPandaOps_logo, get_ethPandaOps_chart_config
-from reorg_normalizer import (
+from pages.analysis.reorgs.reorg_normalizer import (
     normalize_reorg_events, get_reorg_consensus_over_time,
     identify_significant_reorgs
 )

--- a/pages/analysis/reorgs/metrics_calculators.py
+++ b/pages/analysis/reorgs/metrics_calculators.py
@@ -4,7 +4,7 @@ Metrics calculation functions for reorg analysis
 import polars as pl
 import numpy as np
 from typing import Dict, Optional, Tuple
-from config_utils import get_severity_weights, get_episode_clustering_config
+from pages.analysis.reorgs.config_utils import get_severity_weights, get_episode_clustering_config
 
 def calculate_basic_metrics(df: pl.DataFrame) -> Dict:
     """

--- a/pages/analysis/reorgs/page.py
+++ b/pages/analysis/reorgs/page.py
@@ -1,14 +1,5 @@
-# pages/analysis/reorgs/page.py
-import streamlit as st
-import sys
-import os
+"""Chain Reorgs Analysis Dashboard"""
 
-# Add current directory to path for relative imports
-current_dir = os.path.dirname(os.path.abspath(__file__))
-sys.path.append(current_dir)
+from pages.analysis.reorgs.interactive_dashboard import main as run_dashboard
 
-# Import the main dashboard
-from interactive_dashboard import main as run_dashboard
-
-# Run the dashboard
 run_dashboard()

--- a/pages/analysis/reorgs/plot_generators.py
+++ b/pages/analysis/reorgs/plot_generators.py
@@ -9,7 +9,7 @@ from plotly.subplots import make_subplots
 import numpy as np
 from typing import Optional
 from shared.ui_components import add_ethPandaOps_logo
-from config_utils import get_metric_info, get_depth_filter_config
+from pages.analysis.reorgs.config_utils import get_metric_info, get_depth_filter_config
 
 def create_reorg_timeline(df: pl.DataFrame, time_bucket: str = "1h") -> go.Figure:
     """Create a time series visualization of reorg events."""

--- a/pages/analysis/reorgs/reorg_normalizer.py
+++ b/pages/analysis/reorgs/reorg_normalizer.py
@@ -4,7 +4,7 @@ Reorg normalization utilities for identifying common events across nodes
 import polars as pl
 from typing import Tuple, Dict, List
 from datetime import timedelta
-from config_utils import get_client_normalization_rules
+from pages.analysis.reorgs.config_utils import get_client_normalization_rules
 
 def normalize_reorg_events(
     df: pl.DataFrame,

--- a/pages/analysis/validator_performance/__init__.py
+++ b/pages/analysis/validator_performance/__init__.py
@@ -1,0 +1,1 @@
+# Validator Performance analysis package

--- a/pages/analysis/validator_performance/page.py
+++ b/pages/analysis/validator_performance/page.py
@@ -1,26 +1,5 @@
-# pages/analysis/validator_performance/page.py
-"""Entry point for the Validator Performance dashboard."""
-import streamlit as st
-import sys
-import os
+"""Validator Performance Analysis Dashboard"""
 
-# Get current directory and add it to sys.path so imports work
-current_dir = os.path.dirname(os.path.abspath(__file__))
-if current_dir not in sys.path:
-    sys.path.insert(0, current_dir)
+from pages.analysis.validator_performance.interactive_dashboard import run_dashboard
 
-# Import the dashboard module
-try:
-    # Import with the directory in path
-    from interactive_dashboard import run_dashboard
-
-    # Run the dashboard
-    run_dashboard()
-
-except ImportError as e:
-    import traceback
-    st.code(traceback.format_exc())
-except Exception as e:
-    st.error(f"Error running Validator Performance dashboard: {e}")
-    import traceback
-    st.code(traceback.format_exc())
+run_dashboard()


### PR DESCRIPTION
This PR changes the relative imports to absolute imports in streamlit pages. 
When I was running this in my local environment, moving around different pages didn't work and it seemed like the python path and modules were being cached. So even after moving to another view, the previous page was persisting in the contents. 

So instead of manually managing python path to use relative imports, this PR replaces them with absolute imports. 
**Before:**
```python
from config_utils import get_analysis_config
from data_loaders import load_data
```

**After:**
```python
from pages.analysis.multi_metric_analysis.config_utils import get_analysis_config
from pages.analysis.multi_metric_analysis.data_loaders import load_data
```

Let me know if this was just a local environment issue on my end, and this is actually not needed! :) 
