### PR TITLE
Add beacon API events counts analysis page

### DIFF
--- a/app.py
+++ b/app.py
@@ -96,10 +96,17 @@ beacon_api_events_timing_page = st.Page(
     url_path="beacon-api-events-timing"
 )
 
+beacon_api_events_counts_page = st.Page(
+    "pages/analysis/beacon_api_events_counts/page.py",
+    title="Beacon API Events Counts",
+    icon="📊",
+    url_path="beacon-api-events-counts"
+)
+
 # Configure navigation with sections
 navigation = st.navigation({
     "Main": [home_page],
-    "Analysis": [block_producer_performance_page, multi_metric_analysis_page, attestation_cdf_page, validator_performance_page, peerdas_analysis_page, peerdas_analysis_v2_page, gossipsub_monitoring_page, reorgs_page, reorg_rates_page, beacon_api_events_timing_page]
+    "Analysis": [block_producer_performance_page, multi_metric_analysis_page, attestation_cdf_page, validator_performance_page, peerdas_analysis_page, peerdas_analysis_v2_page, gossipsub_monitoring_page, reorgs_page, reorg_rates_page, beacon_api_events_timing_page, beacon_api_events_counts_page]
 })
 
 # Run the selected page

--- a/pages/analysis/beacon_api_events_counts/README.md
+++ b/pages/analysis/beacon_api_events_counts/README.md
@@ -1,0 +1,132 @@
+# Beacon API Events Timing Analysis
+
+An interactive Streamlit dashboard for analyzing timing metrics of Beacon API events and LibP2P gossipsub messages in Ethereum networks.
+
+## Overview
+
+This analysis page provides comprehensive timing analysis of events from two primary data sources:
+
+### Data Sources
+- **Beacon API Events**: block, head, blob_sidecar, attestation, sync_committee
+- **LibP2P Gossipsub**: beacon_block, beacon_attestation, data_column_sidecar, blob_sidecar
+
+The dashboard tracks event propagation delays by measuring time differences between when events occur and when they are received by various consensus clients.
+
+## Features
+
+### Grouping & Filtering
+- **Proposer Grouping**: Analyze timing by proposer characteristics (node type, CL/EL client, architecture, operator, region, datacenter, or combinations)
+- **Receiver Grouping**: Analyze timing by event receiver (CL client type or specific client instances)
+- **Multi-dimensional Filtering**: Filter by proposer metadata, receiver client types, and time ranges
+
+### Visualization Types
+- **Time Series**: Event timing trends over time with percentile bands
+- **Boxplots**: Distribution analysis grouped by proposer/receiver characteristics
+- **Histograms**: Timing distribution with detailed statistics
+- **Statistical Summary**: Comprehensive statistical breakdowns by grouping
+
+### Advanced Controls
+- **Blob Count Bucketing**: Group analysis by number of blobs per slot
+- **Outlier Handling**: Multiple methods (IQR, percentile capping, z-score)
+- **Data Sampling**: Configurable sampling rates for large datasets
+- **Unlimited Mode**: Query complete datasets with safety confirmations
+- **Performance Thresholds**: Cap extreme outliers for focused analysis
+
+## Architecture
+
+### Module Structure
+```
+beacon_api_events_timing/
+├── __init__.py                 # Package initialization
+├── page.py                     # Streamlit page entry point
+├── interactive_dashboard.py    # Main dashboard UI and configuration
+├── loader.py                   # Data loading and caching logic
+├── queries.py                  # SQL query builders
+├── plot_generators.py          # Visualization rendering functions
+└── chart_functions.py          # Additional chart utilities
+```
+
+### Data Flow
+1. **Configuration** (`interactive_dashboard.py`): User selects data source, event type, groupings, filters, and visualization options
+2. **Query Building** (`queries.py`): Constructs SQL queries based on configuration, with dynamic grouping expressions
+3. **Data Loading** (`loader.py`): Fetches data from ClickHouse with caching, applies sampling and limits
+4. **Visualization** (`plot_generators.py`, `chart_functions.py`): Renders charts based on selected visualization type
+
+### Key Components
+
+#### Grouping Expressions (`loader.py`)
+- **Proposer Groups**: Maps grouping options to SQL expressions using validator metadata (vm table)
+- **Receiver Groups**: Maps receiver grouping to CL client metadata fields
+
+#### Query Builders (`queries.py`)
+- **Time Series**: Aggregates timing metrics over time windows
+- **Grouped Samples**: Fetches individual samples with proposer/receiver metadata
+- **Simple Samples**: Fetches raw timing data without grouping
+
+#### Plot Generators (`plot_generators.py`)
+- Time series with percentile bands (P50, P75, P95)
+- Grouped boxplots with outlier handling
+- Data summary metrics
+- Histogram distributions
+
+## Usage
+
+### Basic Analysis
+1. Select data source (Beacon API or LibP2P)
+2. Choose event type
+3. Configure time range
+4. Select grouping dimensions
+5. Click "Analyze Now"
+
+### Advanced Features
+
+#### Blob Bucketing
+Enable to analyze how timing varies with blob count. Useful for identifying performance degradation with higher blob counts.
+
+#### Unlimited Mode
+For comprehensive analysis across large time ranges:
+1. Enable "Unlimited Mode"
+2. Confirm safety check (queries may take 5-15 minutes)
+3. Optionally enable server-side aggregation for better performance
+
+#### Outlier Control
+- **IQR Method**: Filters values beyond 1.5×IQR from quartiles
+- **Percentile**: Caps at specified percentile (e.g., 95th)
+- **Z-Score**: Removes values beyond N standard deviations
+
+## Dependencies
+
+### Shared Utilities
+- `shared.database`: ClickHouse connection management
+- `shared.header`: Global UI header and network selection
+- `shared.ethereum.validator_filters`: Validator metadata filtering
+
+### Data Requirements
+- Beacon API event tables or LibP2P gossipsub tables in ClickHouse
+- Validator metadata (vm) table for proposer grouping
+- Client metadata fields (meta_client_*) for receiver grouping
+
+## Performance Considerations
+
+- **Sampling**: Auto-adjusts based on time range to prevent query timeouts
+- **Caching**: 5-minute TTL on data queries
+- **Record Limits**: Configurable max records (default: 500k, max: 5M)
+- **Threshold Capping**: Performance threshold removes extreme outliers before visualization
+
+## Example Queries
+
+### Timing by CL Client (Proposer)
+- Grouping: "CL Client"
+- Shows which consensus clients propose blocks with better/worse event timing
+
+### Timing by Receiver Client
+- Receiver Grouping: "CL Client Type"
+- Shows which clients receive and report events faster
+
+### Regional Performance
+- Proposer Grouping: "Region"
+- Identifies geographic latency patterns
+
+### Architecture Impact
+- Proposer Grouping: "Architecture"
+- Compares timing across different hardware configurations

--- a/pages/analysis/beacon_api_events_counts/__init__.py
+++ b/pages/analysis/beacon_api_events_counts/__init__.py
@@ -1,0 +1,4 @@
+"""Beacon API Events Timing analysis package."""
+
+
+

--- a/pages/analysis/beacon_api_events_counts/chart_functions.py
+++ b/pages/analysis/beacon_api_events_counts/chart_functions.py
@@ -1,0 +1,187 @@
+"""Additional chart functions for beacon API events counts analysis."""
+
+import streamlit as st
+import pandas as pd
+from typing import Dict, Any
+
+
+def render_histogram_analysis(data: Dict[str, Any], config: Dict[str, Any] = None):
+    """Render focused histogram analysis - shows distribution of event counts."""
+    from pages.analysis.beacon_api_events_counts.plot_generators import apply_blob_bucketing
+
+    samples: pd.DataFrame = data.get('samples', pd.DataFrame())
+    if samples.empty or 'event_count' not in samples.columns:
+        st.info("No event count data available for histogram analysis.")
+        return
+
+    # Apply blob bucketing if enabled
+    samples = apply_blob_bucketing(samples, config)
+    if samples.empty:
+        st.warning("No data available after applying filters.")
+        return
+
+    st.subheader("Event Count Distribution Analysis")
+
+    col1, col2 = st.columns([2, 1])
+
+    with col1:
+        import plotly.express as px
+        fig = px.histogram(
+            samples,
+            x='event_count',
+            nbins=50,
+            title="Event Count Distribution",
+            labels={'event_count': 'Event Count', 'count': 'Frequency'}
+        )
+        st.plotly_chart(fig, use_container_width=True)
+
+    with col2:
+        st.subheader("Distribution Statistics")
+        stats = samples['event_count'].describe()
+
+        # Add additional statistics
+        extended_stats = pd.DataFrame({
+            'Value': [
+                f"{stats['count']:.0f}",
+                f"{stats['mean']:.2f}",
+                f"{stats['std']:.2f}",
+                f"{stats['min']:.0f}",
+                f"{stats['25%']:.0f}",
+                f"{stats['50%']:.0f}",
+                f"{stats['75%']:.0f}",
+                f"{stats['max']:.0f}",
+                f"{samples['event_count'].quantile(0.95):.0f}",
+                f"{samples['event_count'].quantile(0.99):.0f}",
+            ]
+        }, index=[
+            'Count', 'Mean', 'Std Dev', 'Min', 'Q1 (25%)',
+            'Median (50%)', 'Q3 (75%)', 'Max', 'P95', 'P99'
+        ])
+
+        st.dataframe(extended_stats, use_container_width=True)
+
+
+def render_statistical_summary(data: Dict[str, Any], config: Dict[str, Any] = None):
+    """Render statistical summary table view for event counts."""
+    from pages.analysis.beacon_api_events_counts.plot_generators import apply_blob_bucketing
+
+    samples: pd.DataFrame = data.get('samples', pd.DataFrame())
+    if samples.empty:
+        st.info("No data available for statistical summary.")
+        return
+
+    # Filter out empty group labels (but keep 'unknown' - it represents valid data without metadata)
+    original_count = len(samples)
+
+    # Clean proposer_group
+    if 'proposer_group' in samples.columns:
+        samples = samples[
+            samples['proposer_group'].notna() &
+            (samples['proposer_group'].astype(str).str.strip() != '')
+        ].copy()
+
+    # Clean receiver_group
+    if 'receiver_group' in samples.columns:
+        samples = samples[
+            samples['receiver_group'].notna() &
+            (samples['receiver_group'].astype(str).str.strip() != '')
+        ].copy()
+
+    # Apply blob bucketing if enabled
+    samples = apply_blob_bucketing(samples, config)
+    if samples.empty:
+        st.warning("No data available after applying filters.")
+        return
+
+    st.subheader("Statistical Summary")
+
+    if 'proposer_group' in samples.columns and config.get('proposer_grouping', 'none') != 'none':
+        # Group by proposer characteristics
+        st.subheader("Event Count Summary by Proposer Group")
+
+        grouped_stats = samples.groupby('proposer_group')['event_count'].agg([
+            'count', 'sum', 'mean', 'std', 'min',
+            lambda x: x.quantile(0.25),
+            lambda x: x.quantile(0.50),
+            lambda x: x.quantile(0.75),
+            lambda x: x.quantile(0.95),
+            'max'
+        ]).round(2)
+
+        grouped_stats.columns = ['Rows', 'Total Events', 'Mean', 'Std Dev', 'Min', 'Q1', 'Median', 'Q3', 'P95', 'Max']
+
+        st.dataframe(grouped_stats, use_container_width=True)
+
+        # Show group distribution
+        st.subheader("Event Distribution by Proposer Group")
+        group_totals = samples.groupby('proposer_group')['event_count'].sum()
+
+        col1, col2 = st.columns(2)
+        with col1:
+            st.bar_chart(group_totals)
+        with col2:
+            pct_distribution = (group_totals / group_totals.sum() * 100).round(1)
+            pct_df = pd.DataFrame({
+                'Total Events': group_totals,
+                'Percentage': pct_distribution.astype(str) + '%'
+            })
+            st.dataframe(pct_df, use_container_width=True)
+
+    # Also show receiver grouping if available
+    if 'receiver_group' in samples.columns and config.get('receiver_grouping', 'none') != 'none':
+        # Group by receiver characteristics
+        st.subheader("Event Count Summary by Receiver Group")
+
+        grouped_stats = samples.groupby('receiver_group')['event_count'].agg([
+            'count', 'sum', 'mean', 'std', 'min',
+            lambda x: x.quantile(0.25),
+            lambda x: x.quantile(0.50),
+            lambda x: x.quantile(0.75),
+            lambda x: x.quantile(0.95),
+            'max'
+        ]).round(2)
+
+        grouped_stats.columns = ['Rows', 'Total Events', 'Mean', 'Std Dev', 'Min', 'Q1', 'Median', 'Q3', 'P95', 'Max']
+
+        st.dataframe(grouped_stats, use_container_width=True)
+
+        # Show group distribution
+        st.subheader("Event Distribution by Receiver Group")
+        group_totals = samples.groupby('receiver_group')['event_count'].sum()
+
+        col1, col2 = st.columns(2)
+        with col1:
+            st.bar_chart(group_totals)
+        with col2:
+            pct_distribution = (group_totals / group_totals.sum() * 100).round(1)
+            pct_df = pd.DataFrame({
+                'Total Events': group_totals,
+                'Percentage': pct_distribution.astype(str) + '%'
+            })
+            st.dataframe(pct_df, use_container_width=True)
+    else:
+        # Overall statistics
+        st.subheader("Overall Event Count Statistics")
+        if 'event_count' in samples.columns:
+            stats = samples['event_count'].describe()
+
+            # Create a more detailed summary
+            summary_data = {
+                'Metric': ['Rows', 'Total Events', 'Mean', 'Std Dev', 'Min', '25%', '50%', '75%', '95%', '99%', 'Max'],
+                'Value': [
+                    f"{stats['count']:.0f}",
+                    f"{samples['event_count'].sum():.0f}",
+                    f"{stats['mean']:.2f}",
+                    f"{stats['std']:.2f}",
+                    f"{stats['min']:.0f}",
+                    f"{stats['25%']:.0f}",
+                    f"{stats['50%']:.0f}",
+                    f"{stats['75%']:.0f}",
+                    f"{samples['event_count'].quantile(0.95):.0f}",
+                    f"{samples['event_count'].quantile(0.99):.0f}",
+                    f"{stats['max']:.0f}",
+                ]
+            }
+
+            summary_df = pd.DataFrame(summary_data)
+            st.dataframe(summary_df, use_container_width=True, hide_index=True)

--- a/pages/analysis/beacon_api_events_counts/interactive_dashboard.py
+++ b/pages/analysis/beacon_api_events_counts/interactive_dashboard.py
@@ -1,9 +1,9 @@
 """
-Interactive dashboard for Beacon API Events Timing analysis.
+Interactive dashboard for Beacon API Events Counts analysis.
 
 Mirrors the configuration and grouping patterns from peerdas_analysis_v2, but
-operates on beacon API event timing metrics, allowing selection of a specific
-event type and aggregating timing by proposer/attester groupings.
+counts all beacon API event occurrences across all nodes for selected event types,
+aggregating counts by proposer/attester groupings.
 """
 
 import streamlit as st
@@ -16,18 +16,19 @@ from shared.ethereum.validator_filters import (
     create_attester_filters_ui,
 )
 
-from pages.analysis.beacon_api_events_timing.loader import (
-    load_event_timing_grouped,
+from pages.analysis.beacon_api_events_counts.loader import (
+    load_event_counts_grouped,
     get_unique_clients,
 )
 
-from pages.analysis.beacon_api_events_timing.plot_generators import (
+from pages.analysis.beacon_api_events_counts.plot_generators import (
     render_time_series_summary,
     render_group_boxplots,
+    render_group_bar_charts,
     render_data_summary,
 )
 
-from pages.analysis.beacon_api_events_timing.chart_functions import (
+from pages.analysis.beacon_api_events_counts.chart_functions import (
     render_histogram_analysis,
     render_statistical_summary,
 )
@@ -114,7 +115,7 @@ def render_sidebar_config(cluster: str, network: str) -> Dict[str, Any]:
                 "sync_committee",
             ],
             index=0,
-            help="Select the event type table to aggregate timing from",
+            help="Select the event type to count across all nodes",
         )
     else:
         event_type = st.sidebar.selectbox(
@@ -126,7 +127,7 @@ def render_sidebar_config(cluster: str, network: str) -> Dict[str, Any]:
                 "blob_sidecar",
             ],
             index=0,
-            help="Select the libp2p gossipsub message type to analyze",
+            help="Select the libp2p gossipsub message type to count",
         )
 
     # Grouping selections (matching peerdas_analysis_v2 format)
@@ -266,61 +267,23 @@ def render_sidebar_config(cluster: str, network: str) -> Dict[str, Any]:
             help=f"Suggested: {suggested_max:,} for {hours_selected:.1f} hour range. Max: 5M records."
         )
 
-    # Performance threshold - allow higher values for unlimited mode
-    max_threshold = 600000 if unlimited_mode else 300000
-    default_threshold = 300000 if unlimited_mode else 100000
+    # Placeholder for performance_threshold_ms - kept for compatibility with queries
+    # but not exposed to user since we're counting events, not measuring timing
+    performance_threshold_ms = 300000
 
-    performance_threshold_ms = st.sidebar.number_input(
-        "Outlier cap (ms)",
-        min_value=0,
-        max_value=max_threshold,
-        value=default_threshold,
-        help=f"Ignore diffs above this threshold. Max: {max_threshold:,}ms {'(increased for unlimited mode)' if unlimited_mode else ''}"
+    # Event Count Visualization Options
+    st.sidebar.subheader("📊 Visualization Options")
+
+    show_values = st.sidebar.checkbox(
+        "Show Values on Charts",
+        value=True,
+        help="Display count values on bar charts"
     )
 
-    # Outlier Controls
-    st.sidebar.subheader("📈 Outlier Handling")
-
-    outlier_method = st.sidebar.selectbox(
-        "Outlier Filtering",
-        options=['none', 'iqr', 'percentile', 'zscore'],
-        index=1,  # Default to IQR
-        format_func=lambda x: {
-            'none': 'No Filtering',
-            'iqr': 'IQR Method (1.5×IQR)',
-            'percentile': 'Percentile Capping',
-            'zscore': 'Z-Score Method'
-        }[x],
-        help="Method to handle outliers in visualizations"
-    )
-
-    if outlier_method == 'percentile':
-        outlier_percentile = st.sidebar.slider(
-            "Outlier Percentile",
-            min_value=90,
-            max_value=99,
-            value=95,
-            help="Cap outliers above this percentile"
-        )
-    else:
-        outlier_percentile = 95
-
-    if outlier_method == 'zscore':
-        zscore_threshold = st.sidebar.number_input(
-            "Z-Score Threshold",
-            min_value=1.0,
-            max_value=5.0,
-            value=3.0,
-            step=0.5,
-            help="Remove values beyond this many standard deviations"
-        )
-    else:
-        zscore_threshold = 3.0
-
-    show_outliers_toggle = st.sidebar.checkbox(
-        "Show Outliers in Boxplots",
-        value=False,
-        help="Toggle outlier points display in boxplot visualizations"
+    sort_by_count = st.sidebar.checkbox(
+        "Sort by Count",
+        value=True,
+        help="Sort groups by event count (descending)"
     )
 
     # Blob Count Bucketing
@@ -329,7 +292,7 @@ def render_sidebar_config(cluster: str, network: str) -> Dict[str, Any]:
     enable_blob_bucketing = st.sidebar.checkbox(
         "Enable Blob Bucketing",
         value=False,
-        help="Group timing analysis by number of blobs in each slot"
+        help="Group event counts by number of blobs in each slot"
     )
 
     if enable_blob_bucketing:
@@ -350,20 +313,19 @@ def render_sidebar_config(cluster: str, network: str) -> Dict[str, Any]:
         filter_zero_blobs = False
         num_buckets = 1
 
-    # Chart Options (matching peerdas_analysis_v2)
-    st.sidebar.subheader("📊 Chart Options")
+    # Chart Options
+    st.sidebar.subheader("📊 Chart Type")
 
     chart_type = st.sidebar.selectbox(
         "Chart Type",
-        options=['timeseries', 'boxplot', 'histogram', 'summary'],
+        options=['bar', 'timeseries', 'summary'],
         index=0,
         format_func=lambda x: {
-            'timeseries': 'Time Series + Boxplot',
-            'boxplot': 'Boxplot Distribution',
-            'histogram': 'Histogram Distribution',
+            'bar': 'Bar Chart (Grouped)',
+            'timeseries': 'Time Series',
             'summary': 'Statistical Summary'
         }[x],
-        help="Choose the visualization type for event timing analysis"
+        help="Choose the visualization type for event count analysis"
     )
 
     # Action buttons with safety warnings for unlimited mode
@@ -408,10 +370,8 @@ def render_sidebar_config(cluster: str, network: str) -> Dict[str, Any]:
         'period': selected_period if selected_period != "Custom" else None,
         'proposer_filters': proposer_filters,
         'receiver_filters': receiver_filters,
-        'outlier_method': outlier_method,
-        'outlier_percentile': outlier_percentile,
-        'zscore_threshold': zscore_threshold,
-        'show_outliers_toggle': show_outliers_toggle,
+        'show_values': show_values,
+        'sort_by_count': sort_by_count,
         'enable_blob_bucketing': enable_blob_bucketing,
         'filter_zero_blobs': filter_zero_blobs,
         'num_buckets': num_buckets,
@@ -425,7 +385,7 @@ def main():
     cluster = get_global_cluster()
     network = get_global_network()
 
-    st.title("Beacon API Events Timing")
+    st.title("Beacon API Events Counts")
 
     config = render_sidebar_config(cluster=cluster, network=network)
 
@@ -440,13 +400,13 @@ def main():
     if config.get('unlimited_mode'):
         time_range = config['end_date'] - config['start_date']
         hours = time_range.total_seconds() / 3600
-        spinner_text = f"🚀 UNLIMITED MODE: Querying ALL data for {hours:.1f} hours... This may take 5-15 minutes."
+        spinner_text = f"🚀 UNLIMITED MODE: Counting ALL events for {hours:.1f} hours... This may take 5-15 minutes."
         st.warning(f"⚠️ Processing unlimited dataset covering {hours:.1f} hours. Please be patient...")
     else:
-        spinner_text = "Loading data..."
+        spinner_text = "Counting events..."
 
     with st.spinner(spinner_text):
-        data = load_event_timing_grouped(
+        data = load_event_counts_grouped(
             cluster_name=cluster,
             network=network,
             start_date=config['start_date'],
@@ -467,18 +427,14 @@ def main():
     render_data_summary(data, config)
 
     # Render charts based on selected type
-    chart_type = config.get('chart_type', 'timeseries')
+    chart_type = config.get('chart_type', 'bar')
 
-    if chart_type == 'timeseries':
-        # Time series + grouped analysis (default)
+    if chart_type == 'bar':
+        # Bar chart showing grouped event counts (default)
+        render_group_bar_charts(data, config)
+    elif chart_type == 'timeseries':
+        # Time series of event counts over time
         render_time_series_summary(data, config)
-        render_group_boxplots(data, config)
-    elif chart_type == 'boxplot':
-        # Focus on boxplot distribution only
-        render_group_boxplots(data, config)
-    elif chart_type == 'histogram':
-        # Focus on histogram distribution
-        render_histogram_analysis(data, config)
     elif chart_type == 'summary':
         # Statistical summary table
         render_statistical_summary(data, config)

--- a/pages/analysis/beacon_api_events_counts/loader.py
+++ b/pages/analysis/beacon_api_events_counts/loader.py
@@ -1,0 +1,147 @@
+"""
+Data loader for Beacon API Events Counts analysis.
+
+Replicates grouping and filters style from peerdas_analysis_v2 but focuses on
+counting event occurrences across all nodes from beacon API event tables.
+"""
+
+from typing import Dict, Any, List
+from datetime import datetime
+import pandas as pd
+import streamlit as st
+
+from shared.database import get_database_connection
+from shared.ethereum.validator_filters import get_node_classifications
+
+from pages.analysis.beacon_api_events_counts.queries import (
+    build_time_series_query,
+    build_simple_samples_query,
+    build_grouped_samples_query,
+    BEACON_API_TABLES,
+    LIBP2P_TABLES,
+)
+
+
+PROPOSER_GROUP_EXPRESSIONS = {
+    'none': "'all'",
+    'node_type': "coalesce(vm.node_type, 'unknown')",
+    'cl_client': "coalesce(vm.cl_client, 'unknown')",
+    'el_client': "coalesce(vm.el_client, 'unknown')",
+    'architecture': "coalesce(vm.architecture, 'unknown')",
+    'operator': "coalesce(vm.operator, 'unknown')",
+    'region': "coalesce(vm.region, 'unknown')",
+    'datacenter': "coalesce(vm.datacenter, 'unknown')",
+    'cl_el_combined': "coalesce(concat(vm.cl_client, '-', vm.el_client), 'unknown')",
+    'cl_node_type': "coalesce(concat(vm.cl_client, '-', vm.node_type), 'unknown')",
+    'cl_architecture': "coalesce(concat(vm.cl_client, '-', vm.architecture), 'unknown')",
+    'cl_operator': "coalesce(concat(vm.cl_client, '-', vm.operator), 'unknown')",
+    'block_building': "'unknown'",
+    'node_type_mev': "coalesce(concat(vm.node_type, '-', 'unknown'), 'unknown')",
+    'cl_node_type_mev': "coalesce(concat(vm.cl_client, '-', vm.node_type, '-', 'unknown'), 'unknown')",
+}
+
+RECEIVER_GROUP_EXPRESSIONS = {
+    'none': "'all'",
+    'cl_client': "coalesce(vm.cl_client, 'unknown')",
+    'client_instance': "coalesce(vm.client_instance, 'unknown')",
+}
+
+
+@st.cache_data(ttl=300, show_spinner=False, persist=False)
+def get_unique_clients(cluster_name: str, network: str):
+    # Returns a DataFrame of classifications
+    return get_node_classifications(network, cluster_name)
+
+
+@st.cache_data(ttl=120, show_spinner=True, persist=False)
+def load_event_counts_grouped(
+    cluster_name: str,
+    network: str,
+    start_date: datetime,
+    end_date: datetime,
+    data_source: str,
+    event_type: str,
+    proposer_grouping: str,
+    receiver_grouping: str,
+    performance_threshold_ms: int,
+    sample_rate: int,
+    max_records: int,
+    proposer_filters: Dict[str, Any],
+    receiver_filters: Dict[str, Any],
+    enable_blob_bucketing: bool = False,
+) -> Dict[str, Any]:
+    conn = get_database_connection(cluster_name)
+    if not conn:
+        return {"time_series": pd.DataFrame(), "samples": pd.DataFrame()}
+
+    # Time series overview (use limited records for time series to avoid memory issues)
+    ts_max_records = 10000 if max_records != 0 else 0
+    ts_sql = build_time_series_query(network, data_source, event_type, ts_max_records)
+    ts_params = {"start_date": start_date, "end_date": end_date}
+    ts_df = pd.read_sql(ts_sql, conn, params=ts_params)
+
+    # Build grouping expressions
+    prop_expr = PROPOSER_GROUP_EXPRESSIONS.get(proposer_grouping, "'all'")
+    recv_expr = RECEIVER_GROUP_EXPRESSIONS.get(receiver_grouping, "'all'")
+
+    # Build filter SQL snippets
+    def _in_clause(values: List[str]) -> str:
+        if not values:
+            return ""
+        safe = ",".join(f"'{v}'" for v in values)
+        return f" IN ({safe})"
+
+    prop_filter_sql_parts: List[str] = []
+    if proposer_filters.get('proposer_type'):
+        prop_filter_sql_parts.append(f"AND coalesce(vm.node_type, 'unknown') = '{proposer_filters['proposer_type']}'")
+    if proposer_filters.get('proposer_cl'):
+        prop_filter_sql_parts.append(f"AND coalesce(vm.cl_client, 'unknown'){_in_clause(proposer_filters['proposer_cl'])}")
+    if proposer_filters.get('proposer_el'):
+        prop_filter_sql_parts.append(f"AND coalesce(vm.el_client, 'unknown'){_in_clause(proposer_filters['proposer_el'])}")
+    if proposer_filters.get('proposer_architecture'):
+        prop_filter_sql_parts.append(f"AND coalesce(vm.architecture, 'unknown'){_in_clause(proposer_filters['proposer_architecture'])}")
+    if proposer_filters.get('proposer_operator'):
+        prop_filter_sql_parts.append(f"AND coalesce(vm.operator, 'unknown'){_in_clause(proposer_filters['proposer_operator'])}")
+    if proposer_filters.get('proposer_region'):
+        prop_filter_sql_parts.append(f"AND coalesce(vm.region, 'unknown'){_in_clause(proposer_filters['proposer_region'])}")
+    if proposer_filters.get('proposer_datacenter'):
+        prop_filter_sql_parts.append(f"AND coalesce(vm.datacenter, 'unknown'){_in_clause(proposer_filters['proposer_datacenter'])}")
+    proposer_filter_sql = ("\n    " + "\n    ".join(prop_filter_sql_parts)) if prop_filter_sql_parts else ""
+
+    recv_filter_sql_parts: List[str] = []
+    # Event receiver filters using available beacon API metadata
+    if receiver_filters.get('attester_cl'):
+        recv_filter_sql_parts.append(f"AND coalesce(vm.cl_client, 'unknown'){_in_clause(receiver_filters['attester_cl'])}")
+    receiver_filter_sql = ("\n    " + "\n    ".join(recv_filter_sql_parts)) if recv_filter_sql_parts else ""
+
+    # Use grouped query when grouping is enabled, otherwise simple query
+    if proposer_grouping != 'none' or receiver_grouping != 'none':
+        samples_sql = build_grouped_samples_query(
+            network=network,
+            data_source=data_source,
+            event=event_type,
+            performance_threshold_ms=performance_threshold_ms,
+            sample_rate=sample_rate,
+            max_records=max_records,
+            proposer_group_expr=prop_expr,
+            receiver_group_expr=recv_expr,
+            proposer_filter_sql=proposer_filter_sql,
+            receiver_filter_sql=receiver_filter_sql,
+            enable_blob_bucketing=enable_blob_bucketing,
+        )
+    else:
+        samples_sql = build_simple_samples_query(
+            network=network,
+            data_source=data_source,
+            event=event_type,
+            performance_threshold_ms=performance_threshold_ms,
+            sample_rate=sample_rate,
+            max_records=max_records,
+        )
+
+    params = {"start_date": start_date, "end_date": end_date, "performance_threshold_ms": performance_threshold_ms}
+    samples_df = pd.read_sql(samples_sql, conn, params=params)
+
+    return {"time_series": ts_df, "samples": samples_df}
+
+

--- a/pages/analysis/beacon_api_events_counts/page.py
+++ b/pages/analysis/beacon_api_events_counts/page.py
@@ -1,0 +1,8 @@
+"""Beacon API Events Counts Analysis Dashboard"""
+
+from pages.analysis.beacon_api_events_counts.interactive_dashboard import main as run_dashboard
+
+run_dashboard()
+
+
+

--- a/pages/analysis/beacon_api_events_counts/plot_generators.py
+++ b/pages/analysis/beacon_api_events_counts/plot_generators.py
@@ -1,8 +1,8 @@
 """
-Plot generators for Beacon API Events Timing.
+Plot generators for Beacon API Events Counts.
 
-Provides a minimal set of visuals similar to peerdas v2: a time-series
-summary with quantiles and grouped box plots for proposer/attester views.
+Provides visualizations for event count analysis: time-series showing event
+counts over time and grouped bar charts for proposer/receiver views.
 """
 
 import streamlit as st
@@ -133,14 +133,14 @@ def render_data_summary(data: Dict[str, Any], config: Dict[str, Any]):
             st.metric(
                 "Data Source",
                 config.get('data_source', 'unknown').title(),
-                help="Source of timing data: Beacon API events or LibP2P Gossipsub messages"
+                help="Source of event data: Beacon API events or LibP2P Gossipsub messages"
             )
 
         with col2:
             st.metric(
                 "Event Type",
                 config.get('event_type', 'unknown').replace('_', ' ').title(),
-                help="Type of blockchain event being analyzed"
+                help="Type of blockchain event being counted"
             )
 
         with col3:
@@ -156,28 +156,28 @@ def render_data_summary(data: Dict[str, Any], config: Dict[str, Any]):
             st.metric(
                 "Sample Count",
                 f"{sample_count:,}",
-                help="Number of individual event timing measurements"
+                help="Number of aggregated event count records"
             )
 
-        # Second row with timing and filtering info
+        # Second row with count statistics
         col1, col2, col3, col4 = st.columns(4)
 
         with col1:
-            if not samples_df.empty and 'diff_ms' in samples_df.columns:
-                avg_timing = samples_df['diff_ms'].mean()
+            if not samples_df.empty and 'event_count' in samples_df.columns:
+                total_events = samples_df['event_count'].sum()
                 st.metric(
-                    "Avg Timing",
-                    f"{avg_timing:.1f}ms",
-                    help="Average event timing across all samples"
+                    "Total Events",
+                    f"{total_events:,}",
+                    help="Total number of events counted across all groups"
                 )
 
         with col2:
-            if not samples_df.empty and 'diff_ms' in samples_df.columns:
-                p95_timing = samples_df['diff_ms'].quantile(0.95)
+            if not samples_df.empty and 'event_count' in samples_df.columns:
+                avg_count = samples_df['event_count'].mean()
                 st.metric(
-                    "P95 Timing",
-                    f"{p95_timing:.1f}ms",
-                    help="95th percentile event timing"
+                    "Avg Count",
+                    f"{avg_count:.1f}",
+                    help="Average event count per group/slot"
                 )
 
         with col3:
@@ -305,18 +305,18 @@ def render_time_series_summary(data: dict, config: Dict[str, Any] = None):
         return
 
     fig = go.Figure()
-    colors = {"average": "#1f77b4", "p50": "#ff7f0e", "p95": "#d62728"}
 
-    for col, name in [("average", "avg"), ("p50", "p50"), ("p95", "p95")]:
-        if col in df.columns:
-            fig.add_trace(go.Scatter(
-                x=df['time'],
-                y=df[col],
-                mode='lines+markers',
-                name=name,
-                line=dict(color=colors.get(col, "#2ca02c"), width=2),
-                marker=dict(size=4)
-            ))
+    if 'event_count' in df.columns:
+        fig.add_trace(go.Scatter(
+            x=df['time'],
+            y=df['event_count'],
+            mode='lines+markers',
+            name='Event Count',
+            line=dict(color="#1f77b4", width=2),
+            marker=dict(size=4),
+            fill='tozeroy',
+            fillcolor='rgba(31, 119, 180, 0.2)'
+        ))
 
     # Add data source and configuration annotations
     data_source = config.get('data_source', 'unknown') if config else 'unknown'
@@ -325,10 +325,11 @@ def render_time_series_summary(data: dict, config: Dict[str, Any] = None):
 
     # Calculate some basic stats for annotation
     total_points = len(df)
-    if not df.empty and 'average' in df.columns:
-        avg_value = df['average'].mean()
+    if not df.empty and 'event_count' in df.columns:
+        total_events = df['event_count'].sum()
+        avg_count = df['event_count'].mean()
         annotation_text = f"Data: {data_source.title()} | Event: {event_type.replace('_', ' ').title()}<br>"
-        annotation_text += f"Points: {total_points:,} | Sample Rate: {sample_rate}% | Avg: {avg_value:.1f}ms"
+        annotation_text += f"Points: {total_points:,} | Sample Rate: {sample_rate}% | Total Events: {total_events:,} | Avg: {avg_count:.1f}"
     else:
         annotation_text = f"Data: {data_source.title()} | Event: {event_type.replace('_', ' ').title()}<br>"
         annotation_text += f"Points: {total_points:,} | Sample Rate: {sample_rate}%"
@@ -348,9 +349,9 @@ def render_time_series_summary(data: dict, config: Dict[str, Any] = None):
     )
 
     fig.update_layout(
-        title="Event Timing Over Time",
+        title="Event Count Over Time",
         xaxis_title="Time (UTC)",
-        yaxis_title="Timing (ms)",
+        yaxis_title="Event Count",
         legend=dict(
             orientation="h",
             yanchor="bottom",
@@ -380,9 +381,9 @@ def _build_boxplot(df: pd.DataFrame, group_col: str, title: str, config: Dict[st
     show_outliers = config.get('show_outliers_toggle', False) if config else False
     boxpoints = 'outliers' if show_outliers else False
 
-    # Plotly box needs y values per group - filter out empty strings and unknowns
+    # Plotly box needs y values per group - filter out empty strings (but keep 'unknown')
     groups = df[group_col].dropna().unique().tolist()
-    groups = [g for g in groups if g and str(g).strip() and str(g).strip().lower() not in ['', 'unknown', 'null', 'none']]
+    groups = [g for g in groups if g and str(g).strip()]
 
     if not groups:
         st.info(f"No valid groups found for {title} after filtering empty values.")
@@ -483,9 +484,9 @@ def _build_combined_boxplot(df: pd.DataFrame, group_col: str, sort_col: str, tit
     show_outliers = config.get('show_outliers_toggle', False) if config else False
     boxpoints = 'outliers' if show_outliers else False
 
-    # Get unique groups and filter out empty/unknown values
+    # Get unique groups and filter out empty values (but keep 'unknown')
     groups = df[group_col].dropna().unique().tolist()
-    groups = [g for g in groups if g and str(g).strip() and str(g).strip().lower() not in ['', 'unknown', 'null', 'none']]
+    groups = [g for g in groups if g and str(g).strip()]
 
     if not groups:
         st.info(f"No valid groups found for {title} after filtering empty values.")
@@ -579,28 +580,26 @@ def render_group_boxplots(data: dict, config: Dict[str, Any] = None):
         st.info("No samples available.")
         return
 
-    # Filter out rows with empty/invalid group labels early
+    # Filter out rows with empty/invalid group labels (but keep 'unknown' - it represents valid data without metadata)
     original_count = len(samples)
 
     # Clean proposer_group
     if 'proposer_group' in samples.columns:
         samples = samples[
             samples['proposer_group'].notna() &
-            (samples['proposer_group'].astype(str).str.strip() != '') &
-            (~samples['proposer_group'].astype(str).str.lower().isin(['unknown', 'null', 'none']))
+            (samples['proposer_group'].astype(str).str.strip() != '')
         ].copy()
 
     # Clean receiver_group
     if 'receiver_group' in samples.columns:
         samples = samples[
             samples['receiver_group'].notna() &
-            (samples['receiver_group'].astype(str).str.strip() != '') &
-            (~samples['receiver_group'].astype(str).str.lower().isin(['unknown', 'null', 'none']))
+            (samples['receiver_group'].astype(str).str.strip() != '')
         ].copy()
 
     filtered_count = len(samples)
     if original_count > filtered_count:
-        st.info(f"🧹 Filtered out {original_count - filtered_count:,} records with empty/unknown group labels ({(original_count - filtered_count)/original_count*100:.1f}%)")
+        st.info(f"🧹 Filtered out {original_count - filtered_count:,} records with empty group labels ({(original_count - filtered_count)/original_count*100:.1f}%)")
 
     # Apply blob bucketing if enabled
     samples = apply_blob_bucketing(samples, config)
@@ -722,3 +721,271 @@ def _build_simple_histogram(df: pd.DataFrame, config: Dict[str, Any] = None):
 
 
 
+"""
+Helper function for bar chart generation - to be integrated into plot_generators.py
+"""
+
+import streamlit as st
+import pandas as pd
+import plotly.graph_objects as go
+from typing import Dict, Any
+
+
+def _build_bar_chart(df: pd.DataFrame, group_col: str, title: str, config: Dict[str, Any] = None):
+    """Build bar chart showing average events per slot by group."""
+    if df.empty or group_col not in df.columns or 'event_count' not in df.columns or 'slot' not in df.columns:
+        st.info(f"No data for {title}.")
+        return
+
+    # Aggregate: sum event counts and count unique slots per group
+    group_stats = df.groupby(group_col).agg({
+        'event_count': 'sum',
+        'slot': 'nunique'
+    }).reset_index()
+
+    # Calculate average events per slot
+    group_stats['events_per_slot'] = group_stats['event_count'] / group_stats['slot']
+    group_stats.columns = [group_col, 'total_events', 'num_slots', 'events_per_slot']
+
+    # Filter out empty groups (but keep 'unknown' - it represents valid data without metadata)
+    group_stats = group_stats[
+        group_stats[group_col].notna() &
+        (group_stats[group_col].astype(str).str.strip() != '')
+    ]
+
+    if group_stats.empty:
+        st.info(f"No valid groups found for {title}.")
+        return
+
+    # Sort by events per slot if requested
+    if config and config.get('sort_by_count', True):
+        group_stats = group_stats.sort_values('events_per_slot', ascending=False)
+    else:
+        # Sort by blob bucket if applicable, otherwise alphabetically
+        if group_col == 'blob_bucket_label' and 'blob_bucket_sort_key' in df.columns:
+            # Get sort keys for each label
+            label_to_sort = df.groupby('blob_bucket_label')['blob_bucket_sort_key'].first().to_dict()
+            group_stats['sort_key'] = group_stats[group_col].map(label_to_sort)
+            group_stats = group_stats.sort_values('sort_key')
+            group_stats = group_stats.drop('sort_key', axis=1)
+        else:
+            group_stats = group_stats.sort_values(group_col)
+
+    # Create bar chart
+    fig = go.Figure()
+
+    fig.add_trace(go.Bar(
+        x=group_stats[group_col],
+        y=group_stats['events_per_slot'],
+        text=group_stats['events_per_slot'].apply(lambda x: f"{x:.1f}") if config and config.get('show_values', True) else None,
+        textposition='outside',
+        marker_color='#1f77b4',
+        hovertemplate='<b>%{x}</b><br>Events per Slot: %{y:.2f}<br>Total Events: ' +
+                      group_stats['total_events'].astype(str) + '<br>Slots: ' +
+                      group_stats['num_slots'].astype(str) + '<extra></extra>',
+        customdata=group_stats[['total_events', 'num_slots']].values
+    ))
+
+    # Add data source annotation
+    if config:
+        data_source = config.get('data_source', 'unknown')
+        event_type = config.get('event_type', 'unknown')
+        annotation_text = f"Data: {data_source.title()} | Event: {event_type.replace('_', ' ').title()}"
+
+        fig.add_annotation(
+            x=0.02,
+            y=0.98,
+            xref="paper",
+            yref="paper",
+            text=annotation_text,
+            showarrow=False,
+            font=dict(size=9, color="gray"),
+            bgcolor="rgba(255,255,255,0.8)",
+            bordercolor="gray",
+            borderwidth=1,
+            align="left"
+        )
+
+    fig.update_layout(
+        title=title,
+        xaxis_title=group_col.replace('_', ' ').title(),
+        yaxis_title="Events per Slot",
+        margin=dict(t=60, r=10, b=60, l=50),
+        showlegend=False,
+        hovermode='closest'
+    )
+
+    # Rotate x-axis labels if there are many groups
+    if len(group_stats) > 10:
+        fig.update_xaxes(tickangle=-45)
+
+    st.plotly_chart(fig, use_container_width=True)
+
+
+def _build_combined_bar_chart(df: pd.DataFrame, group_col: str, sort_col: str, title: str, config: Dict[str, Any] = None):
+    """Build bar chart for combined groups showing average events per slot."""
+    if df.empty or group_col not in df.columns or 'event_count' not in df.columns or 'slot' not in df.columns:
+        st.info(f"No data for {title}.")
+        return
+
+    # Aggregate: sum event counts and count unique slots per group
+    group_stats = df.groupby(group_col).agg({
+        'event_count': 'sum',
+        'slot': 'nunique'
+    }).reset_index()
+
+    # Calculate average events per slot
+    group_stats['events_per_slot'] = group_stats['event_count'] / group_stats['slot']
+    group_stats.columns = [group_col, 'total_events', 'num_slots', 'events_per_slot']
+
+    # Filter out empty groups (but keep 'unknown' - it represents valid data without metadata)
+    group_stats = group_stats[
+        group_stats[group_col].notna() &
+        (group_stats[group_col].astype(str).str.strip() != '')
+    ]
+
+    if group_stats.empty:
+        st.info(f"No valid groups found for {title}.")
+        return
+
+    # Custom sorting for blob bucket combinations
+    if sort_col in df.columns and 'blob_bucket_sort_key' in df.columns:
+        # Create mapping for sorting
+        group_sort_mapping = {}
+        for group in group_stats[group_col].unique():
+            group_data = df[df[group_col] == group]
+            if not group_data.empty:
+                blob_sort_key = group_data['blob_bucket_sort_key'].iloc[0]
+                secondary_sort = group.split(' blobs: ')[-1] if ' blobs: ' in group else group
+                group_sort_mapping[group] = (blob_sort_key, secondary_sort)
+
+        group_stats['sort_key_1'] = group_stats[group_col].map(lambda x: group_sort_mapping.get(x, (999, x))[0])
+        group_stats['sort_key_2'] = group_stats[group_col].map(lambda x: group_sort_mapping.get(x, (999, x))[1])
+        group_stats = group_stats.sort_values(['sort_key_1', 'sort_key_2'])
+        group_stats = group_stats.drop(['sort_key_1', 'sort_key_2'], axis=1)
+    elif config and config.get('sort_by_count', True):
+        group_stats = group_stats.sort_values('events_per_slot', ascending=False)
+    else:
+        group_stats = group_stats.sort_values(group_col)
+
+    # Create bar chart
+    fig = go.Figure()
+
+    fig.add_trace(go.Bar(
+        x=group_stats[group_col],
+        y=group_stats['events_per_slot'],
+        text=group_stats['events_per_slot'].apply(lambda x: f"{x:.1f}") if config and config.get('show_values', True) else None,
+        textposition='outside',
+        marker_color='#1f77b4',
+        hovertemplate='<b>%{x}</b><br>Events per Slot: %{y:.2f}<br>Total Events: ' +
+                      group_stats['total_events'].astype(str) + '<br>Slots: ' +
+                      group_stats['num_slots'].astype(str) + '<extra></extra>',
+        customdata=group_stats[['total_events', 'num_slots']].values
+    ))
+
+    # Add data source annotation
+    if config:
+        data_source = config.get('data_source', 'unknown')
+        event_type = config.get('event_type', 'unknown')
+        annotation_text = f"Data: {data_source.title()} | Event: {event_type.replace('_', ' ').title()}"
+
+        fig.add_annotation(
+            x=0.02,
+            y=0.98,
+            xref="paper",
+            yref="paper",
+            text=annotation_text,
+            showarrow=False,
+            font=dict(size=9, color="gray"),
+            bgcolor="rgba(255,255,255,0.8)",
+            bordercolor="gray",
+            borderwidth=1,
+            align="left"
+        )
+
+    fig.update_layout(
+        title=title,
+        xaxis_title=group_col.replace('_', ' ').title(),
+        yaxis_title="Events per Slot",
+        margin=dict(t=60, r=10, b=100, l=50),  # More bottom margin for labels
+        showlegend=False,
+        hovermode='closest'
+    )
+
+    # Rotate x-axis labels for readability
+    fig.update_xaxes(tickangle=-45)
+
+    st.plotly_chart(fig, use_container_width=True)
+
+
+def render_group_bar_charts(data: dict, config: Dict[str, Any] = None):
+    """Main function to render bar charts showing event counts by groups."""
+    samples: pd.DataFrame = data.get('samples', pd.DataFrame())
+    if samples.empty:
+        st.info("No samples available.")
+        return
+
+    # Filter out rows with empty/invalid group labels (but keep 'unknown' - it represents valid data without metadata)
+    original_count = len(samples)
+
+    if 'proposer_group' in samples.columns:
+        samples = samples[
+            samples['proposer_group'].notna() &
+            (samples['proposer_group'].astype(str).str.strip() != '')
+        ].copy()
+
+    if 'receiver_group' in samples.columns:
+        samples = samples[
+            samples['receiver_group'].notna() &
+            (samples['receiver_group'].astype(str).str.strip() != '')
+        ].copy()
+
+    filtered_count = len(samples)
+    if original_count > filtered_count:
+        st.info(f"🧹 Filtered out {original_count - filtered_count:,} records with empty group labels ({(original_count - filtered_count)/original_count*100:.1f}%)")
+
+    # Apply blob bucketing if enabled (from existing function)
+    from pages.analysis.beacon_api_events_counts.plot_generators import apply_blob_bucketing
+    samples = apply_blob_bucketing(samples, config)
+    if samples.empty:
+        st.warning("No data available after applying filters.")
+        return
+
+    # Check if blob bucketing is enabled
+    blob_bucketing_enabled = config.get('enable_blob_bucketing', False) and 'blob_bucket_label' in samples.columns
+
+    if blob_bucketing_enabled:
+        st.subheader("Average Events per Slot by Blob Bucket")
+        _build_bar_chart(samples, 'blob_bucket_label', 'Average Events per Slot by Blob Buckets', config)
+
+        # Show grouped analysis within blob buckets if grouping is enabled
+        if 'proposer_group' in samples.columns or 'receiver_group' in samples.columns:
+            st.subheader("Grouped Analysis within Blob Buckets")
+
+            if 'proposer_group' in samples.columns:
+                st.subheader("Blob Bucket × Proposer Analysis")
+                samples['combined_group'] = samples['blob_bucket_label'].astype(str) + ' blobs: ' + samples['proposer_group'].astype(str)
+                _build_combined_bar_chart(samples, 'combined_group', 'blob_bucket_label', 'Average Events per Slot by Blob Bucket × Proposer Group', config)
+
+            if 'receiver_group' in samples.columns:
+                st.subheader("Blob Bucket × Receiver Analysis")
+                samples['combined_group_receiver'] = samples['blob_bucket_label'].astype(str) + ' blobs: ' + samples['receiver_group'].astype(str)
+                _build_combined_bar_chart(samples, 'combined_group_receiver', 'blob_bucket_label', 'Average Events per Slot by Blob Bucket × Receiver Group', config)
+
+    # Show grouped analysis if grouping columns exist (regular mode)
+    elif 'proposer_group' in samples.columns or 'receiver_group' in samples.columns:
+        st.subheader("Average Events per Slot by Group")
+        col1, col2 = st.columns(2)
+        with col1:
+            if 'proposer_group' in samples.columns:
+                _build_bar_chart(samples, 'proposer_group', 'Average Events per Slot by Proposer Groups', config)
+        with col2:
+            if 'receiver_group' in samples.columns:
+                _build_bar_chart(samples, 'receiver_group', 'Average Events per Slot by Receiver Groups', config)
+    else:
+        # Show basic summary
+        st.subheader("Event Count Summary")
+        if 'event_count' in samples.columns:
+            total_events = samples['event_count'].sum()
+            st.metric("Total Events Counted", f"{total_events:,}")
+            st.dataframe(samples[['slot', 'event_count']].head(20), use_container_width=True)

--- a/pages/analysis/beacon_api_events_counts/plot_generators.py
+++ b/pages/analysis/beacon_api_events_counts/plot_generators.py
@@ -9,8 +9,40 @@ import streamlit as st
 import pandas as pd
 import plotly.graph_objects as go
 from plotly.subplots import make_subplots
-from typing import Dict, Any
+from typing import Dict, Any, List
 import numpy as np
+import plotly.express as px
+
+
+def _get_color_palette(n_colors: int) -> List[str]:
+    """Generate a consistent color palette for node groups using Plotly colors."""
+    if n_colors <= 0:
+        return []
+
+    # Use Plotly's qualitative color sequences for consistent, distinguishable colors
+    if n_colors <= 10:
+        return px.colors.qualitative.Plotly[:n_colors]
+    elif n_colors <= 24:
+        return px.colors.qualitative.Dark24[:n_colors]
+    else:
+        # For very large numbers, cycle through multiple palettes
+        colors = []
+        palettes = [
+            px.colors.qualitative.Plotly,
+            px.colors.qualitative.Dark24,
+            px.colors.qualitative.Light24,
+        ]
+        palette_idx = 0
+        color_idx = 0
+
+        for _ in range(n_colors):
+            colors.append(palettes[palette_idx][color_idx])
+            color_idx += 1
+            if color_idx >= len(palettes[palette_idx]):
+                color_idx = 0
+                palette_idx = (palette_idx + 1) % len(palettes)
+
+        return colors
 
 
 def apply_blob_bucketing(df: pd.DataFrame, config: Dict[str, Any]) -> pd.DataFrame:
@@ -823,7 +855,7 @@ def _build_bar_chart(df: pd.DataFrame, group_col: str, title: str, config: Dict[
 
 
 def _build_combined_bar_chart(df: pd.DataFrame, group_col: str, sort_col: str, title: str, config: Dict[str, Any] = None):
-    """Build bar chart for combined groups showing average events per slot."""
+    """Build bar chart with blob buckets grouped together, with visual spacing between bucket groups."""
     if df.empty or group_col not in df.columns or 'event_count' not in df.columns or 'slot' not in df.columns:
         st.info(f"No data for {title}.")
         return
@@ -848,40 +880,129 @@ def _build_combined_bar_chart(df: pd.DataFrame, group_col: str, sort_col: str, t
         st.info(f"No valid groups found for {title}.")
         return
 
-    # Custom sorting for blob bucket combinations
-    if sort_col in df.columns and 'blob_bucket_sort_key' in df.columns:
-        # Create mapping for sorting
-        group_sort_mapping = {}
-        for group in group_stats[group_col].unique():
-            group_data = df[df[group_col] == group]
-            if not group_data.empty:
-                blob_sort_key = group_data['blob_bucket_sort_key'].iloc[0]
-                secondary_sort = group.split(' blobs: ')[-1] if ' blobs: ' in group else group
-                group_sort_mapping[group] = (blob_sort_key, secondary_sort)
+    # Extract blob buckets and node groups from combined labels
+    blob_bucket_to_node_groups = {}
+    blob_bucket_to_sort_key = {}
+    all_node_groups = set()
 
-        group_stats['sort_key_1'] = group_stats[group_col].map(lambda x: group_sort_mapping.get(x, (999, x))[0])
-        group_stats['sort_key_2'] = group_stats[group_col].map(lambda x: group_sort_mapping.get(x, (999, x))[1])
-        group_stats = group_stats.sort_values(['sort_key_1', 'sort_key_2'])
-        group_stats = group_stats.drop(['sort_key_1', 'sort_key_2'], axis=1)
-    elif config and config.get('sort_by_count', True):
-        group_stats = group_stats.sort_values('events_per_slot', ascending=False)
-    else:
-        group_stats = group_stats.sort_values(group_col)
+    for combined_label in group_stats[group_col].unique():
+        if ' blobs: ' in combined_label:
+            parts = combined_label.split(' blobs: ')
+            blob_bucket = parts[0]
+            node_group = parts[1]
 
-    # Create bar chart
+            if blob_bucket not in blob_bucket_to_node_groups:
+                blob_bucket_to_node_groups[blob_bucket] = []
+            blob_bucket_to_node_groups[blob_bucket].append(node_group)
+            all_node_groups.add(node_group)
+
+            # Get sort key for this blob bucket
+            if 'blob_bucket_sort_key' in df.columns:
+                group_data = df[df[group_col] == combined_label]
+                if not group_data.empty:
+                    blob_bucket_to_sort_key[blob_bucket] = group_data['blob_bucket_sort_key'].iloc[0]
+
+    # Sort blob buckets by their sort key
+    blob_buckets = sorted(blob_bucket_to_node_groups.keys(), key=lambda x: blob_bucket_to_sort_key.get(x, 999))
+
+    # Sort node groups within each blob bucket alphabetically
+    for blob_bucket in blob_buckets:
+        blob_bucket_to_node_groups[blob_bucket] = sorted(blob_bucket_to_node_groups[blob_bucket])
+
+    # Create color palette for node groups (consistent across blob buckets)
+    all_node_groups = sorted(list(all_node_groups))
+    color_palette = _get_color_palette(len(all_node_groups))
+    node_group_colors = {node_group: color_palette[i] for i, node_group in enumerate(all_node_groups)}
+
+    # Create x-axis positions with gaps between blob bucket groups
     fig = go.Figure()
+    x_position = 0
+    x_tick_positions = []
+    x_tick_labels = []
+    gap_between_buckets = 1.2  # Gap between different blob bucket groups
+    gap_within_bucket = 0.8    # Gap between node groups within same bucket
+    bar_colors = []
+    bar_x_positions = []
+    bar_y_values = []
+    bar_hover_texts = []
+    bar_custom_data = []
 
+    for blob_bucket_idx, blob_bucket in enumerate(blob_buckets):
+        node_groups = blob_bucket_to_node_groups[blob_bucket]
+
+        for node_group_idx, node_group in enumerate(node_groups):
+            combined_label = f"{blob_bucket} blobs: {node_group}"
+            stats_row = group_stats[group_stats[group_col] == combined_label]
+
+            if not stats_row.empty:
+                stats = stats_row.iloc[0]
+                color = node_group_colors.get(node_group, '#1f77b4')
+
+                bar_x_positions.append(x_position)
+                bar_y_values.append(stats['events_per_slot'])
+                bar_colors.append(color)
+                bar_hover_texts.append(
+                    f"<b>{blob_bucket} blobs<br>{node_group}</b><br>" +
+                    f"Events per Slot: {stats['events_per_slot']:.2f}<br>" +
+                    f"Total Events: {stats['total_events']:,}<br>" +
+                    f"Slots: {stats['num_slots']:,}"
+                )
+                bar_custom_data.append([stats['total_events'], stats['num_slots']])
+
+                x_tick_positions.append(x_position)
+                x_tick_labels.append(f"{blob_bucket}\n{node_group}")
+                x_position += gap_within_bucket
+
+        # Add gap between blob bucket groups
+        x_position += gap_between_buckets
+
+    # Add all bars at once with individual colors
     fig.add_trace(go.Bar(
-        x=group_stats[group_col],
-        y=group_stats['events_per_slot'],
-        text=group_stats['events_per_slot'].apply(lambda x: f"{x:.1f}") if config and config.get('show_values', True) else None,
+        x=bar_x_positions,
+        y=bar_y_values,
+        marker_color=bar_colors,
+        text=[f"{y:.1f}" for y in bar_y_values] if config and config.get('show_values', True) else None,
         textposition='outside',
-        marker_color='#1f77b4',
-        hovertemplate='<b>%{x}</b><br>Events per Slot: %{y:.2f}<br>Total Events: ' +
-                      group_stats['total_events'].astype(str) + '<br>Slots: ' +
-                      group_stats['num_slots'].astype(str) + '<extra></extra>',
-        customdata=group_stats[['total_events', 'num_slots']].values
+        hovertemplate='%{hovertext}<extra></extra>',
+        hovertext=bar_hover_texts,
+        customdata=bar_custom_data,
+        showlegend=False
     ))
+
+    # Add visual separators between blob bucket groups
+    separator_x = 0
+    for blob_bucket_idx, blob_bucket in enumerate(blob_buckets[:-1]):  # Don't add after last group
+        node_count = len(blob_bucket_to_node_groups[blob_bucket])
+        separator_x += (node_count * gap_within_bucket) + (gap_between_buckets / 2)
+
+        fig.add_vline(
+            x=separator_x,
+            line_dash="dash",
+            line_color="lightgray",
+            line_width=1,
+            opacity=0.5
+        )
+
+        separator_x += (gap_between_buckets / 2)
+
+    # Add blob bucket group labels as annotations
+    label_x = 0
+    for blob_bucket in blob_buckets:
+        node_count = len(blob_bucket_to_node_groups[blob_bucket])
+        # Calculate center position for this blob bucket group
+        group_center = label_x + (node_count * gap_within_bucket) / 2 - (gap_within_bucket / 2)
+
+        fig.add_annotation(
+            x=group_center,
+            y=1.05,
+            yref="paper",
+            text=f"<b>{blob_bucket} blobs</b>",
+            showarrow=False,
+            font=dict(size=11, color="darkblue"),
+            xanchor="center"
+        )
+
+        label_x += (node_count * gap_within_bucket) + gap_between_buckets
 
     # Add data source annotation
     if config:
@@ -903,17 +1024,24 @@ def _build_combined_bar_chart(df: pd.DataFrame, group_col: str, sort_col: str, t
             align="left"
         )
 
+    # Interactive usage hint
+    st.info("💡 **Visualization**: Blob buckets are grouped together with visual spacing. Bars within each bucket use consistent colors by node group.")
+
     fig.update_layout(
         title=title,
-        xaxis_title=group_col.replace('_', ' ').title(),
+        xaxis_title="",
         yaxis_title="Events per Slot",
-        margin=dict(t=60, r=10, b=100, l=50),  # More bottom margin for labels
+        margin=dict(t=80, r=10, b=100, l=50),  # More top/bottom margin for labels
         showlegend=False,
-        hovermode='closest'
+        hovermode='closest',
+        xaxis=dict(
+            tickmode='array',
+            tickvals=x_tick_positions,
+            ticktext=x_tick_labels,
+            tickangle=-45,
+            automargin=True
+        )
     )
-
-    # Rotate x-axis labels for readability
-    fig.update_xaxes(tickangle=-45)
 
     st.plotly_chart(fig, use_container_width=True)
 

--- a/pages/analysis/beacon_api_events_counts/queries.py
+++ b/pages/analysis/beacon_api_events_counts/queries.py
@@ -1,0 +1,214 @@
+"""
+Query builders for Beacon API Events Counts analysis.
+
+Provides per-event table mapping and grouped aggregations mirroring peerdas v2
+grouping logic, but returning event counts across all nodes for selected events.
+"""
+
+from typing import Literal
+
+
+EventType = Literal[
+    "block", "head", "blob_sidecar", "attestation", "sync_committee"
+]
+
+
+BEACON_API_TABLES = {
+    "block": "beacon_api_eth_v1_events_block",
+    "head": "beacon_api_eth_v1_events_head",
+    "blob_sidecar": "beacon_api_eth_v1_events_blob_sidecar",
+    "attestation": "beacon_api_eth_v1_events_attestation",
+    "sync_committee": "beacon_api_eth_v1_events_sync_committee"
+}
+
+LIBP2P_TABLES = {
+    "beacon_block": "libp2p_gossipsub_beacon_block",
+    "beacon_attestation": "libp2p_gossipsub_beacon_attestation",
+    "data_column_sidecar": "libp2p_gossipsub_data_column_sidecar",
+    "blob_sidecar": "libp2p_gossipsub_blob_sidecar"
+}
+
+
+BEACON_API_DIFF_COLUMN = {
+    # All diffs are measured as milliseconds vs slot start from Xatu ingestion
+    "block": "propagation_slot_start_diff",
+    "head": "propagation_slot_start_diff",
+    "blob_sidecar": "propagation_slot_start_diff",
+    "attestation": "propagation_slot_start_diff",
+    "sync_committee": "propagation_slot_start_diff",
+}
+
+LIBP2P_DIFF_COLUMN = {
+    # LibP2P gossipsub propagation timing columns
+    "beacon_block": "propagation_slot_start_diff",
+    "beacon_attestation": "propagation_slot_start_diff",
+    "data_column_sidecar": "propagation_slot_start_diff",
+    "blob_sidecar": "propagation_slot_start_diff",
+}
+
+
+def build_time_series_query(network: str, data_source: str, event: str, max_records: int = 10000) -> str:
+    if data_source == "beacon_api":
+        table = BEACON_API_TABLES[event]
+    else:  # libp2p_gossipsub
+        table = LIBP2P_TABLES[event]
+
+    # Use fixed 5-minute buckets; count total events across all nodes
+    return f"""
+SELECT
+  toStartOfFiveMinute(slot_start_date_time) as time,
+  count(*) as event_count,
+  countDistinct(slot) as unique_slots
+FROM `{network}`.{table}
+WHERE
+  slot_start_date_time BETWEEN %(start_date)s AND %(end_date)s
+GROUP BY time
+ORDER BY time ASC{f'\nLIMIT {max_records}' if max_records > 0 else ''}
+"""
+
+
+def build_simple_samples_query(
+    network: str,
+    data_source: str,
+    event: str,
+    performance_threshold_ms: int,
+    sample_rate: int,
+    max_records: int,
+) -> str:
+    if data_source == "beacon_api":
+        table = BEACON_API_TABLES[event]
+    else:  # libp2p_gossipsub
+        table = LIBP2P_TABLES[event]
+
+    # Count events per slot across all nodes
+    sampling_clause = f"AND rand() %% 100 < {sample_rate}" if sample_rate < 100 else ""
+
+    return f"""
+SELECT
+  slot,
+  count(*) AS event_count,
+  max(slot_start_date_time) as slot_start_date_time,
+  'general' AS category
+FROM `{network}`.{table}
+WHERE slot_start_date_time BETWEEN %(start_date)s AND %(end_date)s
+  {sampling_clause}
+GROUP BY slot, category
+ORDER BY slot_start_date_time DESC{f'\nLIMIT {max_records}' if max_records > 0 else ''}
+"""
+
+
+def build_grouped_samples_query(
+    network: str,
+    data_source: str,
+    event: str,
+    performance_threshold_ms: int,
+    sample_rate: int,
+    max_records: int,
+    proposer_group_expr: str,
+    receiver_group_expr: str,
+    proposer_filter_sql: str,
+    receiver_filter_sql: str,
+    enable_blob_bucketing: bool = False,
+) -> str:
+    if data_source == "beacon_api":
+        table = BEACON_API_TABLES[event]
+    else:  # libp2p_gossipsub
+        table = LIBP2P_TABLES[event]
+
+    # Enhanced query with both proposer and receiver grouping
+    # Proposer = validator who proposed the block for this slot
+    # Count all events seen across all nodes for each slot
+
+    blob_count_cte = ""
+    if enable_blob_bucketing:
+        blob_count_cte = f"""
+blob_counts AS (
+  SELECT b1.slot AS slot, toUInt64(length(anyLast(b1.kzg_commitments))) AS blob_count
+  FROM `{network}`.beacon_api_eth_v1_events_data_column_sidecar AS b1
+  WHERE b1.slot_start_date_time BETWEEN %(start_date)s AND %(end_date)s
+  GROUP BY b1.slot
+  UNION ALL
+  SELECT b2.slot AS slot, toUInt64(b2.kzg_commitments_count) AS blob_count
+  FROM `{network}`.libp2p_gossipsub_data_column_sidecar AS b2
+  WHERE b2.slot_start_date_time BETWEEN %(start_date)s AND %(end_date)s
+  GROUP BY b2.slot, b2.kzg_commitments_count
+),
+slot_blob AS (
+  SELECT bc.slot AS slot, max(bc.blob_count) AS blob_count
+  FROM blob_counts bc
+  GROUP BY bc.slot
+),
+"""
+
+    sampling_clause = f"AND rand() %% 100 < {sample_rate}" if sample_rate < 100 else ""
+
+    query = f"""
+WITH {blob_count_cte}base AS (
+  SELECT slot, slot_start_date_time, meta_client_name
+  FROM `{network}`.{table} FINAL
+  WHERE slot_start_date_time BETWEEN %(start_date)s AND %(end_date)s
+    AND meta_client_name != ''
+    {sampling_clause}
+),
+proposer_meta AS (
+  SELECT validator_index, {proposer_group_expr} AS proposer_group
+  FROM (
+    SELECT
+      validator_index,
+      coalesce(arrayElement(splitByChar(':', arrayFilter(x -> startsWith(x, 'cl:'), tags)[1]), 2), 'unknown') AS cl_client,
+      coalesce(arrayElement(splitByChar(':', arrayFilter(x -> startsWith(x, 'el:'), tags)[1]), 2), 'unknown') AS el_client,
+      IF(attributes['isClSupernode'] = 'true', 'supernode', 'regular') AS node_type,
+      IF(arrayExists(x -> x = 'arch:arm', tags) OR lower(name) LIKE '%%%%arm%%%%', 'ARM', 'x86') AS architecture,
+      coalesce(source, 'unknown') AS operator,
+      coalesce(attributes['cloudRegion'], 'unknown') AS region,
+      coalesce(attributes['cloud'], 'unknown') AS datacenter
+    FROM `{network}`.dim_node FINAL
+  ) vm
+  WHERE 1=1 {proposer_filter_sql}
+),
+receiver_meta AS (
+  SELECT DISTINCT meta_client_name, {receiver_group_expr} AS receiver_group
+  FROM (
+    SELECT DISTINCT
+      meta_client_name,
+      -- Use available beacon API metadata columns (corrected names)
+      coalesce(meta_client_implementation,
+        CASE
+          WHEN meta_client_name LIKE '%%lighthouse%%' THEN 'lighthouse'
+          WHEN meta_client_name LIKE '%%prysm%%' THEN 'prysm'
+          WHEN meta_client_name LIKE '%%teku%%' THEN 'teku'
+          WHEN meta_client_name LIKE '%%nimbus%%' THEN 'nimbus'
+          WHEN meta_client_name LIKE '%%lodestar%%' THEN 'lodestar'
+          WHEN meta_client_name LIKE '%%grandine%%' THEN 'grandine'
+          ELSE 'unknown'
+        END
+      ) AS cl_client,
+      'unknown' AS geo_continent,
+      coalesce(meta_client_name, 'unknown') AS client_instance
+    FROM `{network}`.{table} FINAL
+    WHERE meta_client_name != ''
+  ) vm
+  WHERE 1=1 {receiver_filter_sql}
+)
+SELECT
+  b.slot AS slot,
+  CASE
+    WHEN pm.proposer_group IS NOT NULL THEN pm.proposer_group
+    ELSE 'unknown'
+  END AS proposer_group,
+  CASE
+    WHEN rm.receiver_group IS NOT NULL THEN rm.receiver_group
+    ELSE 'unknown'
+  END AS receiver_group,
+  count(*) AS event_count,
+  max(b.slot_start_date_time) as slot_start_date_time{', sb.blob_count as blob_count' if enable_blob_bucketing else ''}
+FROM base b
+LEFT JOIN `{network}`.int_block_proposer_head iph ON b.slot = iph.slot
+LEFT JOIN proposer_meta pm ON iph.proposer_validator_index = pm.validator_index
+LEFT JOIN receiver_meta rm ON b.meta_client_name = rm.meta_client_name{' LEFT JOIN slot_blob sb ON b.slot = sb.slot' if enable_blob_bucketing else ''}
+GROUP BY b.slot, proposer_group, receiver_group{', sb.blob_count' if enable_blob_bucketing else ''}
+ORDER BY slot_start_date_time DESC{f'\nLIMIT {max_records}' if max_records > 0 else ''}
+"""
+    return query
+
+

--- a/pages/analysis/beacon_api_events_timing/plot_generators.py
+++ b/pages/analysis/beacon_api_events_timing/plot_generators.py
@@ -9,8 +9,43 @@ import streamlit as st
 import pandas as pd
 import plotly.graph_objects as go
 from plotly.subplots import make_subplots
-from typing import Dict, Any
+from typing import Dict, Any, List
 import numpy as np
+import plotly.express as px
+
+
+def _get_color_palette(n_colors: int) -> List[str]:
+    """Generate a consistent color palette for node groups using Plotly colors."""
+    if n_colors <= 0:
+        return []
+
+    # Use Plotly's qualitative color sequences for consistent, distinguishable colors
+    # These are designed to be visually distinct and colorblind-friendly
+    if n_colors <= 10:
+        # Use Plotly's default color sequence (D3 categorical)
+        return px.colors.qualitative.Plotly[:n_colors]
+    elif n_colors <= 24:
+        # Use extended color palette
+        return px.colors.qualitative.Dark24[:n_colors]
+    else:
+        # For very large numbers, cycle through multiple palettes
+        colors = []
+        palettes = [
+            px.colors.qualitative.Plotly,
+            px.colors.qualitative.Dark24,
+            px.colors.qualitative.Light24,
+        ]
+        palette_idx = 0
+        color_idx = 0
+
+        for _ in range(n_colors):
+            colors.append(palettes[palette_idx][color_idx])
+            color_idx += 1
+            if color_idx >= len(palettes[palette_idx]):
+                color_idx = 0
+                palette_idx = (palette_idx + 1) % len(palettes)
+
+        return colors
 
 
 def apply_blob_bucketing(df: pd.DataFrame, config: Dict[str, Any]) -> pd.DataFrame:
@@ -467,7 +502,7 @@ def _build_boxplot(df: pd.DataFrame, group_col: str, title: str, config: Dict[st
 
 
 def _build_combined_boxplot(df: pd.DataFrame, group_col: str, sort_col: str, title: str, config: Dict[str, Any] = None):
-    """Build boxplot for combined groups with custom sorting by blob bucket first."""
+    """Build boxplot with blob buckets grouped together, with visual spacing between bucket groups."""
     if df.empty or group_col not in df.columns:
         st.info(f"No data for {title}.")
         return
@@ -491,47 +526,114 @@ def _build_combined_boxplot(df: pd.DataFrame, group_col: str, sort_col: str, tit
         st.info(f"No valid groups found for {title} after filtering empty values.")
         return
 
-    # Custom sorting: first by blob bucket, then by proposer/receiver group
-    if sort_col in df.columns and 'blob_bucket_sort_key' in df.columns:
-        # Create a mapping for sorting combined groups
-        group_sort_mapping = {}
-        for group in groups:
-            # Extract blob bucket and group info
-            group_data = df[df[group_col] == group]
-            if not group_data.empty:
-                blob_sort_key = group_data['blob_bucket_sort_key'].iloc[0]
-                # Extract the part after "blobs: " for secondary sorting
-                secondary_sort = group.split(' blobs: ')[-1] if ' blobs: ' in group else group
-                group_sort_mapping[group] = (blob_sort_key, secondary_sort)
-
-        # Sort groups by blob bucket first, then by secondary group
-        groups = sorted(groups, key=lambda x: group_sort_mapping.get(x, (999, x)))
-
-    fig = go.Figure()
+    # Extract blob buckets and node groups from combined labels
+    blob_bucket_to_node_groups = {}
+    blob_bucket_to_sort_key = {}
+    all_node_groups = set()
 
     for g in groups:
-        vals = df.loc[df[group_col] == g, 'diff_ms']
-        if not vals.empty:
-            fig.add_trace(go.Box(
-                y=vals,
-                name=str(g),
-                boxpoints=boxpoints,
-                jitter=0.3,
-                hovertemplate=f"Group: {g}<br>Value: %{{y:.1f}}ms<br>Count: {len(vals):,}<extra></extra>"
-            ))
+        if ' blobs: ' in g:
+            parts = g.split(' blobs: ')
+            blob_bucket = parts[0]
+            node_group = parts[1]
 
-    # Add sample count annotations
-    for idx, g in enumerate(groups):
-        vals = df.loc[df[group_col] == g, 'diff_ms']
-        if not vals.empty:
-            fig.add_annotation(
-                x=idx,
-                y=vals.min() - (vals.max() - vals.min()) * 0.1,
-                text=f"n={len(vals):,}",
-                showarrow=False,
-                font=dict(size=9, color="gray"),
-                yshift=-10
-            )
+            if blob_bucket not in blob_bucket_to_node_groups:
+                blob_bucket_to_node_groups[blob_bucket] = []
+            blob_bucket_to_node_groups[blob_bucket].append(node_group)
+            all_node_groups.add(node_group)
+
+            # Get sort key for this blob bucket
+            if 'blob_bucket_sort_key' in df.columns:
+                group_data = df[df[group_col] == g]
+                if not group_data.empty:
+                    blob_bucket_to_sort_key[blob_bucket] = group_data['blob_bucket_sort_key'].iloc[0]
+
+    # Sort blob buckets by their sort key
+    blob_buckets = sorted(blob_bucket_to_node_groups.keys(), key=lambda x: blob_bucket_to_sort_key.get(x, 999))
+
+    # Sort node groups within each blob bucket alphabetically
+    for blob_bucket in blob_buckets:
+        blob_bucket_to_node_groups[blob_bucket] = sorted(blob_bucket_to_node_groups[blob_bucket])
+
+    # Create color palette for node groups (consistent across blob buckets)
+    all_node_groups = sorted(list(all_node_groups))
+    color_palette = _get_color_palette(len(all_node_groups))
+    node_group_colors = {node_group: color_palette[i] for i, node_group in enumerate(all_node_groups)}
+
+    # Create x-axis positions with gaps between blob bucket groups
+    fig = go.Figure()
+    x_position = 0
+    x_tick_positions = []
+    x_tick_labels = []
+    gap_between_buckets = 1.5  # Gap between different blob bucket groups
+    gap_within_bucket = 0.8    # Gap between node groups within same bucket
+
+    for blob_bucket_idx, blob_bucket in enumerate(blob_buckets):
+        node_groups = blob_bucket_to_node_groups[blob_bucket]
+
+        for node_group_idx, node_group in enumerate(node_groups):
+            combined_label = f"{blob_bucket} blobs: {node_group}"
+            if combined_label in groups:
+                vals = df.loc[df[group_col] == combined_label, 'diff_ms']
+                if not vals.empty:
+                    color = node_group_colors.get(node_group, '#1f77b4')
+
+                    fig.add_trace(go.Box(
+                        y=vals,
+                        name=node_group,  # Legend shows node group
+                        legendgroup=node_group,
+                        showlegend=(blob_bucket_idx == 0),  # Only show in legend once
+                        x=[x_position] * len(vals),
+                        marker=dict(color=color),
+                        line=dict(color=color),
+                        boxpoints=boxpoints,
+                        jitter=0.3,
+                        width=0.6,
+                        hovertemplate=f"{blob_bucket} blobs<br>{node_group}<br>Value: %{{y:.1f}}ms<br>Count: {len(vals):,}<extra></extra>"
+                    ))
+
+                    x_tick_positions.append(x_position)
+                    x_tick_labels.append(f"{blob_bucket}\n{node_group}")
+                    x_position += gap_within_bucket
+
+        # Add gap between blob bucket groups
+        x_position += gap_between_buckets
+
+    # Add visual separators between blob bucket groups
+    y_range = [df['diff_ms'].min(), df['diff_ms'].max()]
+    separator_x = 0
+    for blob_bucket_idx, blob_bucket in enumerate(blob_buckets[:-1]):  # Don't add after last group
+        node_count = len(blob_bucket_to_node_groups[blob_bucket])
+        separator_x += (node_count * gap_within_bucket) + (gap_between_buckets / 2)
+
+        fig.add_vline(
+            x=separator_x,
+            line_dash="dash",
+            line_color="lightgray",
+            line_width=1,
+            opacity=0.5
+        )
+
+        separator_x += (gap_between_buckets / 2)
+
+    # Add blob bucket group labels as annotations
+    label_x = 0
+    for blob_bucket in blob_buckets:
+        node_count = len(blob_bucket_to_node_groups[blob_bucket])
+        # Calculate center position for this blob bucket group
+        group_center = label_x + (node_count * gap_within_bucket) / 2 - (gap_within_bucket / 2)
+
+        fig.add_annotation(
+            x=group_center,
+            y=1.05,
+            yref="paper",
+            text=f"<b>{blob_bucket} blobs</b>",
+            showarrow=False,
+            font=dict(size=11, color="darkblue"),
+            xanchor="center"
+        )
+
+        label_x += (node_count * gap_within_bucket) + gap_between_buckets
 
     # Add data source annotation
     if config:
@@ -553,10 +655,14 @@ def _build_combined_boxplot(df: pd.DataFrame, group_col: str, sort_col: str, tit
             align="left"
         )
 
+    # Interactive usage hint
+    st.info("💡 **Visualization**: Blob buckets are grouped together with visual spacing. Node groups within each bucket use consistent colors. Click legend items to show/hide specific node types.")
+
     fig.update_layout(
         title=title,
+        xaxis_title="",
         yaxis_title="Timing (ms)",
-        margin=dict(t=60, r=50, b=40, l=10),  # More right margin for legend
+        margin=dict(t=80, r=50, b=100, l=10),  # More top/bottom margin for labels
         showlegend=True,  # Enable interactive legend
         legend=dict(
             orientation="v",
@@ -568,7 +674,14 @@ def _build_combined_boxplot(df: pd.DataFrame, group_col: str, sort_col: str, tit
             bordercolor="rgba(0,0,0,0.2)",
             borderwidth=1
         ),
-        hovermode='closest'
+        hovermode='closest',
+        xaxis=dict(
+            tickmode='array',
+            tickvals=x_tick_positions,
+            ticktext=x_tick_labels,
+            tickangle=-45,
+            automargin=True
+        )
     )
     st.plotly_chart(fig, use_container_width=True)
 


### PR DESCRIPTION
  ## Summary
  Add new **Beacon API Events Counts** analysis page to track event occurrence patterns across the network. This dashboard counts all beacon API and libp2p gossipsub event occurrences
  across all nodes, providing visibility into event propagation and network coverage.

  ## Motivation
  While the existing `beacon_api_events_timing` page measures *when* events arrive at nodes, this new page answers complementary questions:
  - **How many times** is each event seen across all network nodes?
  - Do certain proposer characteristics (CL client, node type, etc.) correlate with different event propagation patterns?
  - How does blob count affect the number of event observations in the network?
  - Are events being received consistently across different receiver types?

  This helps identify:
  - Network propagation efficiency
  - Potential event flooding or suppression issues
  - Client-specific broadcasting behavior
  - Impact of blob counts on event visibility


<img width="1019" height="1006" alt="Screenshot 2025-10-11 at 11 24 48 PM" src="https://github.com/user-attachments/assets/40b0cedf-f4d1-4acc-8a8e-a3bdcef3d472" />
